### PR TITLE
Add missing rule to the cluster role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+- Initial implementation of the operator added. An admin user can be created in the Superset
+  database with the Init command which takes the credentials from a secret ([#7], [#12]).
+
+[#7]: https://github.com/stackabletech/superset-operator/pull/7
+[#12]: https://github.com/stackabletech/superset-operator/pull/12

--- a/deploy/role/superset-cluster-role.yaml
+++ b/deploy/role/superset-cluster-role.yaml
@@ -43,6 +43,7 @@ rules:
       - get
       - list
       - patch
+      - watch
   - apiGroups:
       - command.superset.stackable.tech
     resources:


### PR DESCRIPTION
## Description

The operator is now allowed to watch for commands. The missing rule was not detected by the integration tests because the Init command is applied so early that the test case was able to "get" it and did not need to "watch" for it.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
