### PR TITLE
[Merged by Bors] - Enable Prometheus metrics using statsd-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Druid DB connections can now be configured in a custom resource ([#71]).
+- Prometheus metrics enabled ([#128]).
 
 ### Changed
 
@@ -19,6 +20,7 @@
 [#70]: https://github.com/stackabletech/superset-operator/pull/70
 [#71]: https://github.com/stackabletech/superset-operator/pull/71
 [#82]: https://github.com/stackabletech/superset-operator/pull/82
+[#128]: https://github.com/stackabletech/superset-operator/pull/128
 
 ## [0.2.0] - 2021-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Added
 
 - Druid DB connections can now be configured in a custom resource ([#71]).
-- Prometheus metrics enabled ([#128]).
+- BREAKING: Prometheus metrics enabled ([#128]); The `statsdExporterVersion`
+  must be set in the cluster specification.
 
 ### Changed
 

--- a/deploy/crd/supersetcluster.crd.yaml
+++ b/deploy/crd/supersetcluster.crd.yaml
@@ -114,6 +114,9 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                statsdExporterVersion:
+                  nullable: true
+                  type: string
                 stopped:
                   description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
                   nullable: true

--- a/deploy/helm/superset-operator/crds/crds.yaml
+++ b/deploy/helm/superset-operator/crds/crds.yaml
@@ -191,6 +191,9 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                statsdExporterVersion:
+                  nullable: true
+                  type: string
                 stopped:
                   description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
                   nullable: true

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -193,6 +193,9 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                statsdExporterVersion:
+                  nullable: true
+                  type: string
                 stopped:
                   description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
                   nullable: true

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -58,6 +58,7 @@ metadata:
   name: superset
 spec:
   version: 1.3.2
+  statsdExporterVersion: v0.22.4
   credentialsSecret: simple-superset-credentials
   loadExamplesOnInit: true
   nodes:
@@ -70,6 +71,8 @@ spec:
 `metadata.name` contains the name of the Superset cluster.
 
 The label of the Docker image provided by Stackable must be set in `spec.version`.
+
+`spec.statsdExporterVersion` must contain the tag of a statsd-exporter Docker image in the Stackable repository.
 
 The previously created secret must be referenced in `spec.credentialsSecret`.
 
@@ -132,3 +135,8 @@ In `spec.druid` you specify the `name` and `namespace` of your Druid cluster.
 Once the database is initialized, the connection will be added to the cluster by the operator. You can see it in the user interface under Data > Databases:
 
 image::superset-databases.png[Superset databases showing the connected Druid cluster]
+
+== Monitoring
+
+The managed HBase instances are automatically configured to export Prometheus metrics. See
+xref:home::monitoring.adoc[] for more details.

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -138,5 +138,5 @@ image::superset-databases.png[Superset databases showing the connected Druid clu
 
 == Monitoring
 
-The managed HBase instances are automatically configured to export Prometheus metrics. See
+The managed Superset instances are automatically configured to export Prometheus metrics. See
 xref:home::monitoring.adoc[] for more details.

--- a/examples/simple-superset-cluster.yaml
+++ b/examples/simple-superset-cluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: superset
 spec:
   version: 1.3.2
+  statsdExporterVersion: v0.22.4
   credentialsSecret: simple-superset-credentials
   loadExamplesOnInit: true
   nodes:

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -40,6 +40,8 @@ pub struct SupersetClusterSpec {
     /// Desired Superset version
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub statsd_exporter_version: Option<String>,
     pub credentials_secret: String,
     #[serde(default)]
     pub load_examples_on_init: Option<bool>,

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -222,7 +222,6 @@ fn build_node_rolegroup_service(
                 statsd_exporter_version(superset).context(NoStatsdExporterVersionSnafu)?,
             )
             .with_label("prometheus.io/scrape", "true")
-            .with_label("prometheus.io/port", METRICS_PORT.to_string())
             .build(),
         spec: Some(ServiceSpec {
             cluster_ip: Some("None".to_string()),

--- a/rust/operator-binary/src/util.rs
+++ b/rust/operator-binary/src/util.rs
@@ -9,6 +9,8 @@ use stackable_superset_crd::SupersetCluster;
 pub enum Error {
     #[snafu(display("object defines no version"))]
     ObjectHasNoVersion,
+    #[snafu(display("object defines no stats exporter version"))]
+    ObjectHasNoStatsdExporterVersion,
 }
 
 pub enum JobState {
@@ -41,6 +43,14 @@ pub fn get_job_state(job: &Job) -> JobState {
 
 pub fn superset_version(superset: &SupersetCluster) -> Result<&str, Error> {
     superset.spec.version.as_deref().context(ObjectHasNoVersion)
+}
+
+pub fn statsd_exporter_version(superset: &SupersetCluster) -> Result<&str, Error> {
+    superset
+        .spec
+        .statsd_exporter_version
+        .as_deref()
+        .context(ObjectHasNoStatsdExporterVersion)
 }
 
 pub fn env_var_from_secret(var_name: &str, secret: &str, secret_key: &str) -> EnvVar {


### PR DESCRIPTION
## Description

Enable Prometheus metrics using statsd-exporter

Tested by stackabletech/integration-tests#150

Closes #95 

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
