### PR TITLE
[Merged by Bors] - Add support for Superset 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Reconciliation errors are now reported as Kubernetes events ([#132]).
+- Add support for Superset 1.4.1 ([#135]).
 - Use cli argument `watch-namespace` / env var `WATCH_NAMESPACE` to specify
   a single namespace to watch ([#138]).
 
@@ -13,6 +14,7 @@
 - `operator-rs` `0.9.0` -> `0.13.0` ([#132],[#138]).
 
 [#132]: https://github.com/stackabletech/superset-operator/pull/132
+[#135]: https://github.com/stackabletech/superset-operator/pull/135
 [#138]: https://github.com/stackabletech/superset-operator/pull/138
 
 ## [0.3.0] - 2022-02-14

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -57,7 +57,7 @@ kind: SupersetCluster
 metadata:
   name: superset
 spec:
-  version: 1.3.2
+  version: 1.4.1
   statsdExporterVersion: v0.22.4
   credentialsSecret: simple-superset-credentials
   loadExamplesOnInit: true

--- a/docs/modules/ROOT/partials/supported-versions.adoc
+++ b/docs/modules/ROOT/partials/supported-versions.adoc
@@ -3,3 +3,4 @@
 // Stackable Platform documentation.
 
 - 1.3.2
+- 1.4.1

--- a/examples/simple-superset-cluster.yaml
+++ b/examples/simple-superset-cluster.yaml
@@ -18,7 +18,7 @@ kind: SupersetCluster
 metadata:
   name: simple-superset
 spec:
-  version: 1.3.2
+  version: 1.4.1
   statsdExporterVersion: v0.22.4
   credentialsSecret: simple-superset-credentials
   loadExamplesOnInit: true


### PR DESCRIPTION
## Description

Add support for Superset 1.4.1

Closes #109 

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

[![Build Actions Status](https://ci.stackable.tech/job/Superset%20Operator%20Integration%20Tests%20(flex)/15/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/Superset%20Operator%20Integration%20Tests%20(flex)/15/)

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
