### PR TITLE
[Merged by Bors] - docs: Improve port-forward command

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -93,7 +93,7 @@ The Superset port which defaults to `8088` can be forwarded to the local host:
 
 [source,bash]
 ----
-kubectl port-forward superset-node-default-0 8088
+kubectl port-forward service/simple-superset-external 8088
 ----
 
 Then it can be opened in the browser with `http://localhost:8088`.


### PR DESCRIPTION
## Description
IMHO its better to connect to the service rather than the Pod. The Pod name is actually outdated, its now `simple-superset-node-default-0`

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
