### PR TITLE
[Merged by Bors] - fixup ability to detect MAP BOX API key and add it to the environment…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Ability to add MAPBOX_API_KEY from secret added ([#178]).
+
+[#178]: https://github.com/stackabletech/superset-operator/pull/178
+
+## [Unreleased]
+
+### Added
+
 - Configuration option `rowLimit` added ([#173]).
 - Configuration and environment overrides enabled ([#173]).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,12 @@
 
 ### Added
 
-- Ability to add MAPBOX_API_KEY from secret added ([#178]).
-
-[#178]: https://github.com/stackabletech/superset-operator/pull/178
-
-## [Unreleased]
-
-### Added
-
 - Configuration option `rowLimit` added ([#173]).
 - Configuration and environment overrides enabled ([#173]).
+- Ability to add MAPBOX_API_KEY from secret added ([#178]).
 
 [#173]: https://github.com/stackabletech/superset-operator/pull/173
+[#178]: https://github.com/stackabletech/superset-operator/pull/178
 
 ## [0.4.0] - 2022-04-05
 

--- a/deploy/crd/supersetcluster.crd.yaml
+++ b/deploy/crd/supersetcluster.crd.yaml
@@ -27,6 +27,9 @@ spec:
                 loadExamplesOnInit:
                   nullable: true
                   type: boolean
+                mapboxSecret:
+                  nullable: true
+                  type: string
                 nodes:
                   nullable: true
                   properties:

--- a/deploy/helm/superset-operator/crds/crds.yaml
+++ b/deploy/helm/superset-operator/crds/crds.yaml
@@ -29,6 +29,9 @@ spec:
                 loadExamplesOnInit:
                   nullable: true
                   type: boolean
+                mapboxSecret:
+                  nullable: true
+                  type: string
                 nodes:
                   nullable: true
                   properties:

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -30,6 +30,9 @@ spec:
                 loadExamplesOnInit:
                   nullable: true
                   type: boolean
+                mapboxSecret:
+                  nullable: true
+                  type: string
                 nodes:
                   nullable: true
                   properties:

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -88,6 +88,7 @@ pub struct SupersetClusterSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub statsd_exporter_version: Option<String>,
     pub credentials_secret: String,
+    pub mapbox_secret: Option<String>,
     #[serde(default)]
     pub load_examples_on_init: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -134,6 +135,7 @@ pub struct SupersetConfig {
 
 impl SupersetConfig {
     pub const CREDENTIALS_SECRET_PROPERTY: &'static str = "credentialsSecret";
+    pub const MAPBOX_SECRET_PROPERTY: &'static str = "mapboxSecret";
 }
 
 impl Configuration for SupersetConfig {
@@ -144,11 +146,14 @@ impl Configuration for SupersetConfig {
         cluster: &Self::Configurable,
         _role_name: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
-        Ok([(
-            Self::CREDENTIALS_SECRET_PROPERTY.to_string(),
-            Some(cluster.spec.credentials_secret.clone()),
-        )]
-        .into())
+        let mut result = BTreeMap::new();
+
+        result.insert(Self::CREDENTIALS_SECRET_PROPERTY.to_string(), Some(cluster.spec.credentials_secret.clone()));
+        if let Some(msec) = &cluster.spec.mapbox_secret {
+            result.insert(Self::MAPBOX_SECRET_PROPERTY.to_string(), Some(msec.clone()));
+        }
+
+        Ok(result)
     }
 
     fn compute_cli(

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -147,8 +147,10 @@ impl Configuration for SupersetConfig {
         _role_name: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
         let mut result = BTreeMap::new();
-
-        result.insert(Self::CREDENTIALS_SECRET_PROPERTY.to_string(), Some(cluster.spec.credentials_secret.clone()));
+        result.insert(
+            Self::CREDENTIALS_SECRET_PROPERTY.to_string(),
+            Some(cluster.spec.credentials_secret.clone()),
+        );
         if let Some(msec) = &cluster.spec.mapbox_secret {
             result.insert(Self::MAPBOX_SECRET_PROPERTY.to_string(), Some(msec.clone()));
         }

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -19,12 +19,12 @@ use stackable_operator::{
         api::{
             apps::v1::{StatefulSet, StatefulSetSpec},
             core::v1::{
-                ConfigMap, ConfigMapVolumeSource, Service, ServicePort, ServiceSpec, Volume
+                ConfigMap, ConfigMapVolumeSource, Service, ServicePort, ServiceSpec, Volume,
             },
         },
         apimachinery::pkg::apis::meta::v1::LabelSelector,
     },
-    kube::{runtime::controller::{Action, Context}},
+    kube::runtime::controller::{Action, Context},
     labels::{role_group_selector_labels, role_selector_labels},
     logging::controller::ReconcilerError,
     product_config::{
@@ -402,8 +402,7 @@ fn build_server_rolegroup_statefulset(
                 &value,
                 "connections.sqlalchemyDatabaseUri",
             );
-        }
-        else if name == SupersetConfig::MAPBOX_SECRET_PROPERTY {
+        } else if name == SupersetConfig::MAPBOX_SECRET_PROPERTY {
             cb.add_env_var_from_secret("MAPBOX_API_KEY", &value, "connections.mapboxApiKey");
         } else {
             cb.add_env_var(name, value);

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -19,12 +19,13 @@ use stackable_operator::{
         api::{
             apps::v1::{StatefulSet, StatefulSetSpec},
             core::v1::{
-                ConfigMap, ConfigMapVolumeSource, Service, ServicePort, ServiceSpec, Volume,
+                ConfigMap, ConfigMapVolumeSource, Service, ServicePort, ServiceSpec, Volume, Secret
             },
         },
         apimachinery::pkg::apis::meta::v1::LabelSelector,
     },
-    kube::runtime::controller::{Action, Context},
+    kube::{runtime::controller::{Action, Context}, ResourceExt},
+    error::OperatorResult,
     labels::{role_group_selector_labels, role_selector_labels},
     logging::controller::ReconcilerError,
     product_config::{
@@ -176,7 +177,7 @@ pub async fn reconcile_superset(
         let rg_service = build_node_rolegroup_service(&rolegroup, &superset)?;
         let rg_configmap = build_rolegroup_config_map(&superset, &rolegroup, rolegroup_config)?;
         let rg_statefulset =
-            build_server_rolegroup_statefulset(&rolegroup, &superset, rolegroup_config)?;
+            build_server_rolegroup_statefulset(&rolegroup, &superset, rolegroup_config, &ctx).await?;
         client
             .apply_patch(FIELD_MANAGER_SCOPE, &rg_service, &rg_service)
             .await
@@ -365,10 +366,11 @@ fn build_node_rolegroup_service(
 /// The rolegroup [`StatefulSet`] runs the rolegroup, as configured by the administrator.
 ///
 /// The [`Pod`](`stackable_operator::k8s_openapi::api::core::v1::Pod`)s are accessible through the corresponding [`Service`] (from [`build_node_rolegroup_service`]).
-fn build_server_rolegroup_statefulset(
+async fn build_server_rolegroup_statefulset(
     rolegroup_ref: &RoleGroupRef<SupersetCluster>,
     superset: &SupersetCluster,
     node_config: &HashMap<PropertyNameKind, BTreeMap<String, String>>,
+    ctx: &Context<Ctx>,
 ) -> Result<StatefulSet> {
     let rolegroup = superset
         .spec
@@ -405,6 +407,39 @@ fn build_server_rolegroup_statefulset(
         } else {
             cb.add_env_var(name, value);
         };
+    }
+
+    let secret_name = node_config
+        .get(&PropertyNameKind::Env)
+        .and_then(|vars| vars.get(SupersetConfig::CREDENTIALS_SECRET_PROPERTY))
+        .unwrap();
+    
+    let namespace_name = superset
+        .namespace()
+        .unwrap();
+
+    let client = &ctx.get_ref().client;
+
+    let s : OperatorResult<Secret> = client.get(secret_name, Some(&namespace_name)).await;
+
+    let s = match s {
+        Ok(sec) => sec,
+        Err(error) => {
+            panic!("Problem obtaining secret {:?}", error)
+        },
+    };
+   
+    // if the mapbox api key is configured set the env variable
+    if let Some(map) = s.data {
+        match map.get("connections.mapBoxApiKey") { 
+            Some(api_key) => {
+
+                let key = String::from_utf8(api_key.0.clone()).unwrap(); 
+
+                cb.add_env_var("MAPBOX_API_KEY", key);
+            },
+            None => ()
+        }
     }
 
     let container = cb


### PR DESCRIPTION
… if present.

## Description

Addition of ability to add the lookup for the MAP_BOX_API key that Superset can use to obtain geo information and map backgrounds for lat / long style queries.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
