### PR TITLE
[Merged by Bors] - Update SupersetConfigOptions to include explicit config for MapboxApiKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 - Configuration option `rowLimit` added ([#173]).
 - Configuration and environment overrides enabled ([#173]).
 - Ability to add MAPBOX_API_KEY from secret added ([#178]).
+- Update SupersetConfigOptions to include explicit config for MapboxApiKey ([#179])
 
 [#173]: https://github.com/stackabletech/superset-operator/pull/173
 [#178]: https://github.com/stackabletech/superset-operator/pull/178
+[#179]: https://github.com/stackabletech/superset-operator/pull/179
 
 ## [0.4.0] - 2022-04-05
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -35,6 +35,7 @@ pub enum SupersetConfigOptions {
     SqlalchemyDatabaseUri,
     StatsLogger,
     RowLimit,
+    MapboxApiKey,
 }
 
 impl SupersetConfigOptions {
@@ -56,6 +57,7 @@ impl FlaskAppConfigOptions for SupersetConfigOptions {
             SupersetConfigOptions::SecretKey => PythonType::Expression,
             SupersetConfigOptions::SqlalchemyDatabaseUri => PythonType::Expression,
             SupersetConfigOptions::StatsLogger => PythonType::Expression,
+            SupersetConfigOptions::MapboxApiKey => PythonType::Expression,
         }
     }
 }

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -254,6 +254,11 @@ fn build_rolegroup_config_map(
         .unwrap_or_default();
 
     config.insert(
+        SupersetConfigOptions::MapboxApiKey.to_string(),
+        "os.environ.get('MAPBOX_API_KEY')".into(),
+    );
+
+    config.insert(
         SupersetConfigOptions::SecretKey.to_string(),
         "os.environ.get('SECRET_KEY')".into(),
     );


### PR DESCRIPTION
## Description

Explicity updated the supserset_config.py for the MAPBOX_API_KEY

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
