### PR TITLE
[Merged by Bors] - Change required product image version to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@
 - Ability to add MAPBOX_API_KEY from secret added ([#178]).
 - Update SupersetConfigOptions to include explicit config for MapboxApiKey ([#179])
 
+### Changed
+
+- Required product image version changed to 2 ([#182]).
+
 [#173]: https://github.com/stackabletech/superset-operator/pull/173
 [#178]: https://github.com/stackabletech/superset-operator/pull/178
 [#179]: https://github.com/stackabletech/superset-operator/pull/179
+[#182]: https://github.com/stackabletech/superset-operator/pull/182
 
 ## [0.4.0] - 2022-04-05
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -19,7 +19,7 @@ use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 pub const APP_NAME: &str = "superset";
 pub const MANAGED_BY: &str = "superset-operator";
 
-pub const PYTHONPATH: &str = "/app/pythonpath";
+pub const PYTHONPATH: &str = "/stackable/app/pythonpath";
 pub const SUPERSET_CONFIG_FILENAME: &str = "superset_config.py";
 
 #[derive(Debug, Snafu)]

--- a/rust/operator-binary/src/druid_connection_controller.rs
+++ b/rust/operator-binary/src/druid_connection_controller.rs
@@ -247,7 +247,7 @@ async fn build_import_job(
 
     let container = ContainerBuilder::new("superset-import-druid-connection")
         .image(format!(
-            "docker.stackable.tech/stackable/superset:{}-stackable1",
+            "docker.stackable.tech/stackable/superset:{}-stackable2",
             superset_db.spec.superset_version
         ))
         .command(vec!["/bin/sh".to_string()])

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -385,7 +385,7 @@ fn build_server_rolegroup_statefulset(
 
     let superset_version = superset_version(superset).context(NoSupersetVersionSnafu)?;
 
-    let image = format!("docker.stackable.tech/stackable/superset:{superset_version}-stackable1");
+    let image = format!("docker.stackable.tech/stackable/superset:{superset_version}-stackable2");
 
     let statsd_exporter_version =
         statsd_exporter_version(superset).context(NoStatsdExporterVersionSnafu)?;

--- a/rust/operator-binary/src/superset_db_controller.rs
+++ b/rust/operator-binary/src/superset_db_controller.rs
@@ -172,7 +172,7 @@ fn build_init_job(superset_db: &SupersetDB) -> Result<Job> {
 
     let container = ContainerBuilder::new("superset-init-db")
         .image(format!(
-            "docker.stackable.tech/stackable/superset:{}-stackable1",
+            "docker.stackable.tech/stackable/superset:{}-stackable2",
             superset_db.spec.superset_version
         ))
         .command(vec!["/bin/bash".to_string()])


### PR DESCRIPTION
## Description

The location of the Superset configuration file was changed in the Superset product image version 2 (see stackabletech/docker-images#103). The location was adapted and the required version set to 2.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
