### PR TITLE
[Merged by Bors] - Set secret key when upgrading the Superset database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@
 
 - Required product image version changed to 2 ([#182]).
 
+### Fixed
+
+- The correct secret key is used when upgrading the Superset database. This
+  issue was introduced in [#173] ([#190]).
+
 [#173]: https://github.com/stackabletech/superset-operator/pull/173
 [#178]: https://github.com/stackabletech/superset-operator/pull/178
 [#179]: https://github.com/stackabletech/superset-operator/pull/179
 [#182]: https://github.com/stackabletech/superset-operator/pull/182
+[#190]: https://github.com/stackabletech/superset-operator/pull/190
 
 ## [0.4.0] - 2022-04-05
 

--- a/rust/operator-binary/src/superset_db_controller.rs
+++ b/rust/operator-binary/src/superset_db_controller.rs
@@ -148,7 +148,12 @@ pub async fn reconcile_superset_db(
 }
 
 fn build_init_job(superset_db: &SupersetDB) -> Result<Job> {
-    let config = "import os; SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URI')";
+    let config = [
+        "import os",
+        "SECRET_KEY = os.environ.get('SECRET_KEY')",
+        "SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URI')",
+    ]
+    .join("; ");
 
     let mut commands = vec![
         format!("mkdir -p {PYTHONPATH}"),
@@ -182,6 +187,7 @@ fn build_init_job(superset_db: &SupersetDB) -> Result<Job> {
             String::from("-c"),
             commands.join("; "),
         ])
+        .add_env_var_from_secret("SECRET_KEY", secret, "connections.secretKey")
         .add_env_var_from_secret("DATABASE_URI", secret, "connections.sqlalchemyDatabaseUri")
         .add_env_var_from_secret("ADMIN_USERNAME", secret, "adminUser.username")
         .add_env_var_from_secret("ADMIN_FIRSTNAME", secret, "adminUser.firstname")


### PR DESCRIPTION
## Description

Set secret key when upgrading the Superset database

The default secret key was used when upgrading the Superset database. This caused an "Invalid decryption key" error when accessing the database view.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
