### PR TITLE
Upgrade stackable-operator to version 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
  "quote",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0489fc937cc7616a9abfa61bf39c250d7e32e1325ef028c8d9278dd24ea395b3"
+checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
 dependencies = [
  "base64",
  "bytes",
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.71.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342744dfeb81fe186b84f485b33f12c6a15d3396987d933b06a566a3db52ca38"
+checksum = "f68b954ea9ad888de953fb1488bd8f377c4c78d82d4642efa5925189210b50b7"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.71.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f69a504997799340408635d6e351afb8aab2c34ca3165e162f41b3b34a69a79"
+checksum = "9150dc7107d9acf4986088f284a0a6dddc5ae37ef1ffdf142f6811dc5998dd58"
 dependencies = [
  "base64",
  "bytes",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.71.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a247487699941baaf93438d65b12d4e32450bea849d619d19ed394e8a4a645"
+checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.71.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203f7c5acf9d0dfb0b08d44ec1d66ace3d1dfe0cdd82e65e274f3f96615d666c"
+checksum = "bfb405f0d39181acbfdc7c79e3fc095330c9b6465ab50aeb662d762e53b662f1"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -911,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.71.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ea50e6ed56578e1d1d02548901b12fe6d3edbf110269a396955e285d487973"
+checksum = "b6e9e9da456f0101b77f864a9da44866b9891ad4740db508b4b269343ebeb01d"
 dependencies = [
  "ahash",
  "backoff",
@@ -1565,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1651,8 +1651,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.19.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.19.0#f8f2d5527b3463cc40f3d851172af7ae81db75c1"
+version = "0.22.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.22.0#5543877169d27770578e634d0d734aa6126f838c"
 dependencies = [
  "backoff",
  "chrono",
@@ -1685,8 +1685,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.17.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.19.0#f8f2d5527b3463cc40f3d851172af7ae81db75c1"
+version = "0.22.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.22.0#5543877169d27770578e634d0d734aa6126f838c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1983,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.5"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
 dependencies = [
  "base64",
  "bitflags",
@@ -2074,13 +2074,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
 dependencies = [
  "ansi_term",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "sharded-slab",
  "smallvec",

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -10,6 +10,6 @@ version = "0.6.0-nightly"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.19.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }
 strum = { version = "0.24", features = ["derive"] }
 snafu = "0.7"

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -15,7 +15,7 @@ futures = { version = "0.3", features = ["compat"] }
 serde = "1.0"
 serde_yaml = "0.8"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.19.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }
 stackable-superset-crd = { path = "../crd" }
 strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.19", features = ["macros", "rt-multi-thread"] }
@@ -23,5 +23,5 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.19.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }
 stackable-superset-crd = { path = "../crd" }

--- a/rust/operator-binary/src/druid_connection_controller.rs
+++ b/rust/operator-binary/src/druid_connection_controller.rs
@@ -10,10 +10,7 @@ use stackable_operator::{
     },
     kube::{
         core::DynamicObject,
-        runtime::{
-            controller::{Action, Context},
-            reflector::ObjectRef,
-        },
+        runtime::{controller::Action, reflector::ObjectRef},
         ResourceExt,
     },
     logging::controller::ReconcilerError,
@@ -103,11 +100,11 @@ impl ReconcilerError for Error {
 
 pub async fn reconcile_druid_connection(
     druid_connection: Arc<DruidConnection>,
-    ctx: Context<Ctx>,
+    ctx: Arc<Ctx>,
 ) -> Result<Action> {
     tracing::info!("Starting reconciling DruidConnections");
 
-    let client = &ctx.get_ref().client;
+    let client = &ctx.client;
 
     if let Some(ref s) = druid_connection.status {
         match s.condition {
@@ -313,6 +310,6 @@ async fn build_import_job(
     Ok(job)
 }
 
-pub fn error_policy(_error: &Error, _ctx: Context<Ctx>) -> Action {
+pub fn error_policy(_error: &Error, _ctx: Arc<Ctx>) -> Action {
     Action::requeue(Duration::from_secs(5))
 }

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -4,6 +4,8 @@ mod superset_controller;
 mod superset_db_controller;
 mod util;
 
+use std::sync::Arc;
+
 use clap::Parser;
 use futures::StreamExt;
 use stackable_operator::{
@@ -16,7 +18,7 @@ use stackable_operator::{
     },
     kube::{
         api::ListParams,
-        runtime::{controller::Context, reflector::ObjectRef, Controller},
+        runtime::{reflector::ObjectRef, Controller},
         CustomResourceExt, ResourceExt,
     },
     logging::controller::report_controller_reconciled,
@@ -25,7 +27,6 @@ use stackable_superset_crd::{
     druidconnection::DruidConnection, supersetdb::SupersetDB, SupersetCluster,
     SupersetClusterAuthenticationConfig,
 };
-use std::sync::Arc;
 
 mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -129,7 +130,7 @@ async fn main() -> anyhow::Result<()> {
                 .run(
                     superset_controller::reconcile_superset,
                     superset_controller::error_policy,
-                    Context::new(superset_controller::Ctx {
+                    Arc::new(superset_controller::Ctx {
                         client: client.clone(),
                         product_config,
                     }),
@@ -186,7 +187,7 @@ async fn main() -> anyhow::Result<()> {
                 .run(
                     superset_db_controller::reconcile_superset_db,
                     superset_db_controller::error_policy,
-                    Context::new(superset_db_controller::Ctx {
+                    Arc::new(superset_db_controller::Ctx {
                         client: client.clone(),
                     }),
                 )
@@ -255,7 +256,7 @@ async fn main() -> anyhow::Result<()> {
                 .run(
                     druid_connection_controller::reconcile_druid_connection,
                     druid_connection_controller::error_policy,
-                    Context::new(druid_connection_controller::Ctx {
+                    Arc::new(druid_connection_controller::Ctx {
                         client: client.clone(),
                     }),
                 )

--- a/rust/operator-binary/src/superset_db_controller.rs
+++ b/rust/operator-binary/src/superset_db_controller.rs
@@ -8,10 +8,7 @@ use stackable_operator::{
         core::v1::{PodSpec, PodTemplateSpec, Secret},
     },
     kube::{
-        runtime::{
-            controller::{Action, Context},
-            reflector::ObjectRef,
-        },
+        runtime::{controller::Action, reflector::ObjectRef},
         ResourceExt,
     },
     logging::controller::ReconcilerError,
@@ -66,13 +63,10 @@ impl ReconcilerError for Error {
     }
 }
 
-pub async fn reconcile_superset_db(
-    superset_db: Arc<SupersetDB>,
-    ctx: Context<Ctx>,
-) -> Result<Action> {
+pub async fn reconcile_superset_db(superset_db: Arc<SupersetDB>, ctx: Arc<Ctx>) -> Result<Action> {
     tracing::info!("Starting reconcile");
 
-    let client = &ctx.get_ref().client;
+    let client = &ctx.client;
 
     if let Some(ref s) = superset_db.status {
         match s.condition {
@@ -226,6 +220,6 @@ fn build_init_job(superset_db: &SupersetDB) -> Result<Job> {
     Ok(job)
 }
 
-pub fn error_policy(_error: &Error, _ctx: Context<Ctx>) -> Action {
+pub fn error_policy(_error: &Error, _ctx: Arc<Ctx>) -> Action {
     Action::requeue(Duration::from_secs(5))
 }


### PR DESCRIPTION
# Description

Upgrade stackable-operator to version 0.22.0

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
