### PR TITLE
[Merged by Bors] - Upgrade stackable-operator to version 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Include chart name when installing with a custom release name ([#227], [#228]).
 - Orphaned resources are deleted ([#255]).
+- `operator-rs` `0.22.0` -> `0.25.0` ([#255]).
 
 [#227]: https://github.com/stackabletech/superset-operator/pull/227
 [#228]: https://github.com/stackabletech/superset-operator/pull/228

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Changed
 
 - Include chart name when installing with a custom release name ([#227], [#228]).
+- Orphaned resources are deleted ([#255]).
 
 [#227]: https://github.com/stackabletech/superset-operator/pull/227
 [#228]: https://github.com/stackabletech/superset-operator/pull/228
+[#255]: https://github.com/stackabletech/superset-operator/pull/255
 
 ## [0.5.0] - 2022-06-30
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "async-trait"
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byteorder"
@@ -360,9 +360,9 @@ checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding"
@@ -727,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.44"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68b954ea9ad888de953fb1488bd8f377c4c78d82d4642efa5925189210b50b7"
+checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150dc7107d9acf4986088f284a0a6dddc5ae37ef1ffdf142f6811dc5998dd58"
+checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
 dependencies = [
  "base64",
  "bytes",
@@ -892,7 +892,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "thiserror",
  "tokio",
  "tokio-native-tls",
@@ -904,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8c429676abe6a73b374438d5ca02caaf9ae7a635441253c589b779fa5d0622"
+checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb405f0d39181acbfdc7c79e3fc095330c9b6465ab50aeb662d762e53b662f1"
+checksum = "66d74121eb41af4480052901f31142d8d9bbdf1b7c6b856da43bcb02f5b1b177"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e9e9da456f0101b77f864a9da44866b9891ad4740db508b4b269343ebeb01d"
+checksum = "8fdcf5a20f968768e342ef1a457491bb5661fccd81119666d626c57500b16d99"
 dependencies = [
  "ahash",
  "backoff",
@@ -965,9 +965,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.131"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libgit2-sys"
@@ -1109,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "openssl"
@@ -1267,18 +1267,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1353,7 +1353,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "thiserror",
  "xml-rs",
 ]
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -1567,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1589,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1609,6 +1609,19 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1678,10 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.22.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.22.0#5543877169d27770578e634d0d734aa6126f838c"
+version = "0.25.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.25.0#490ef77e05d86a0bc2b555fd5950593d9f3a5d4b"
 dependencies = [
- "backoff",
  "chrono",
  "clap",
  "const_format",
@@ -1700,7 +1712,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.10",
  "stackable-operator-derive",
  "strum",
  "thiserror",
@@ -1712,8 +1724,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.22.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.22.0#5543877169d27770578e634d0d734aa6126f838c"
+version = "0.25.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.25.0#490ef77e05d86a0bc2b555fd5950593d9f3a5d4b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1742,7 +1754,6 @@ dependencies = [
  "fnv",
  "futures 0.3.23",
  "serde",
- "serde_yaml",
  "snafu",
  "stackable-operator",
  "stackable-superset-crd",
@@ -2159,6 +2170,12 @@ name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
 
 [[package]]
 name = "url"

--- a/deploy/crd/druidconnection.crd.yaml
+++ b/deploy/crd/druidconnection.crd.yaml
@@ -13,61 +13,63 @@ spec:
     singular: druidconnection
   scope: Namespaced
   versions:
-    - additionalPrinterColumns: []
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "Auto-generated derived type for DruidConnectionSpec via `CustomResource`"
-          properties:
-            spec:
-              properties:
-                druid:
-                  properties:
-                    name:
-                      type: string
-                    namespace:
-                      nullable: true
-                      type: string
-                  required:
-                    - name
-                  type: object
-                superset:
-                  properties:
-                    name:
-                      type: string
-                    namespace:
-                      nullable: true
-                      type: string
-                  required:
-                    - name
-                  type: object
-              required:
-                - druid
-                - superset
-              type: object
-            status:
-              nullable: true
-              properties:
-                condition:
-                  enum:
-                    - Pending
-                    - Importing
-                    - Ready
-                    - Failed
-                  type: string
-                startedAt:
-                  description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
-                  format: date-time
-                  nullable: true
-                  type: string
-              required:
-                - condition
-              type: object
-          required:
-            - spec
-          title: DruidConnection
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns: []
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for DruidConnectionSpec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              druid:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    nullable: true
+                    type: string
+                required:
+                - name
+                type: object
+              superset:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    nullable: true
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - druid
+            - superset
+            type: object
+          status:
+            nullable: true
+            properties:
+              condition:
+                enum:
+                - Pending
+                - Importing
+                - Ready
+                - Failed
+                type: string
+              startedAt:
+                description: Time is a wrapper around time.Time which supports correct
+                  marshaling to YAML and JSON.  Wrappers are provided for many of
+                  the factory methods that the time package offers.
+                format: date-time
+                nullable: true
+                type: string
+            required:
+            - condition
+            type: object
+        required:
+        - spec
+        title: DruidConnection
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/crd/supersetcluster.crd.yaml
+++ b/deploy/crd/supersetcluster.crd.yaml
@@ -10,168 +10,192 @@ spec:
     kind: SupersetCluster
     plural: supersetclusters
     shortNames:
-      - superset
+    - superset
     singular: supersetcluster
   scope: Namespaced
   versions:
-    - additionalPrinterColumns: []
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "Auto-generated derived type for SupersetClusterSpec via `CustomResource`"
-          properties:
-            spec:
-              properties:
-                authenticationConfig:
-                  nullable: true
-                  properties:
-                    authenticationClass:
-                      description: Name of the AuthenticationClass used to authenticate the users. At the moment only LDAP is supported. If not specified the default authentication (AUTH_DB) will be used.
-                      nullable: true
+  - additionalPrinterColumns: []
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for SupersetClusterSpec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              authenticationConfig:
+                nullable: true
+                properties:
+                  authenticationClass:
+                    description: Name of the AuthenticationClass used to authenticate
+                      the users. At the moment only LDAP is supported. If not specified
+                      the default authentication (AUTH_DB) will be used.
+                    nullable: true
+                    type: string
+                  syncRolesAt:
+                    default: Registration
+                    description: If we should replace ALL the user's roles each login,
+                      or only on registration. Gets mapped to `AUTH_ROLES_SYNC_AT_LOGIN`
+                    enum:
+                    - Registration
+                    - Login
+                    type: string
+                  userRegistration:
+                    default: true
+                    description: Allow users who are not already in the FAB DB. Gets
+                      mapped to `AUTH_USER_REGISTRATION`
+                    type: boolean
+                  userRegistrationRole:
+                    default: Public
+                    description: This role will be given in addition to any AUTH_ROLES_MAPPING.
+                      Gets mapped to `AUTH_USER_REGISTRATION_ROLE`
+                    type: string
+                type: object
+              credentialsSecret:
+                type: string
+              loadExamplesOnInit:
+                nullable: true
+                type: boolean
+              mapboxSecret:
+                nullable: true
+                type: string
+              nodes:
+                nullable: true
+                properties:
+                  cliOverrides:
+                    additionalProperties:
                       type: string
-                    syncRolesAt:
-                      default: Registration
-                      description: "If we should replace ALL the user's roles each login, or only on registration. Gets mapped to `AUTH_ROLES_SYNC_AT_LOGIN`"
-                      enum:
-                        - Registration
-                        - Login
-                      type: string
-                    userRegistration:
-                      default: true
-                      description: "Allow users who are not already in the FAB DB. Gets mapped to `AUTH_USER_REGISTRATION`"
-                      type: boolean
-                    userRegistrationRole:
-                      default: Public
-                      description: "This role will be given in addition to any AUTH_ROLES_MAPPING. Gets mapped to `AUTH_USER_REGISTRATION_ROLE`"
-                      type: string
-                  type: object
-                credentialsSecret:
-                  type: string
-                loadExamplesOnInit:
-                  nullable: true
-                  type: boolean
-                mapboxSecret:
-                  nullable: true
-                  type: string
-                nodes:
-                  nullable: true
-                  properties:
-                    cliOverrides:
+                    default: {}
+                    type: object
+                  config:
+                    default: {}
+                    properties:
+                      rowLimit:
+                        format: int32
+                        nullable: true
+                        type: integer
+                    type: object
+                  configOverrides:
+                    additionalProperties:
                       additionalProperties:
                         type: string
-                      default: {}
                       type: object
-                    config:
-                      default: {}
+                    default: {}
+                    type: object
+                  envOverrides:
+                    additionalProperties:
+                      type: string
+                    default: {}
+                    type: object
+                  roleGroups:
+                    additionalProperties:
                       properties:
-                        rowLimit:
-                          format: int32
+                        cliOverrides:
+                          additionalProperties:
+                            type: string
+                          default: {}
+                          type: object
+                        config:
+                          default: {}
+                          properties:
+                            rowLimit:
+                              format: int32
+                              nullable: true
+                              type: integer
+                          type: object
+                        configOverrides:
+                          additionalProperties:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          default: {}
+                          type: object
+                        envOverrides:
+                          additionalProperties:
+                            type: string
+                          default: {}
+                          type: object
+                        replicas:
+                          format: uint16
+                          minimum: 0.0
                           nullable: true
                           type: integer
-                      type: object
-                    configOverrides:
-                      additionalProperties:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      default: {}
-                      type: object
-                    envOverrides:
-                      additionalProperties:
-                        type: string
-                      default: {}
-                      type: object
-                    roleGroups:
-                      additionalProperties:
-                        properties:
-                          cliOverrides:
-                            additionalProperties:
-                              type: string
-                            default: {}
-                            type: object
-                          config:
-                            default: {}
-                            properties:
-                              rowLimit:
-                                format: int32
-                                nullable: true
-                                type: integer
-                            type: object
-                          configOverrides:
-                            additionalProperties:
+                        selector:
+                          description: A label selector is a label query over a set
+                            of resources. The result of matchLabels and matchExpressions
+                            are ANDed. An empty label selector matches all objects.
+                            A null label selector matches no objects.
+                          nullable: true
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
                               type: object
-                            default: {}
-                            type: object
-                          envOverrides:
-                            additionalProperties:
-                              type: string
-                            default: {}
-                            type: object
-                          replicas:
-                            format: uint16
-                            minimum: 0.0
-                            nullable: true
-                            type: integer
-                          selector:
-                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-                            nullable: true
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                items:
-                                  description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector applies to.
-                                      type: string
-                                    operator:
-                                      description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
-                                      type: string
-                                    values:
-                                      description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
-                                type: object
-                            type: object
-                        type: object
+                          type: object
                       type: object
-                  required:
-                    - roleGroups
-                  type: object
-                statsdExporterVersion:
-                  nullable: true
-                  type: string
-                stopped:
-                  description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
-                  nullable: true
-                  type: boolean
-                version:
-                  description: Desired Superset version
-                  nullable: true
-                  type: string
-              required:
-                - credentialsSecret
-              type: object
-            status:
-              nullable: true
-              type: object
-          required:
-            - spec
-          title: SupersetCluster
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    type: object
+                required:
+                - roleGroups
+                type: object
+              statsdExporterVersion:
+                nullable: true
+                type: string
+              stopped:
+                description: Emergency stop button, if `true` then all pods are stopped
+                  without affecting configuration (as setting `replicas` to `0` would)
+                nullable: true
+                type: boolean
+              version:
+                description: Desired Superset version
+                nullable: true
+                type: string
+            required:
+            - credentialsSecret
+            type: object
+          status:
+            nullable: true
+            type: object
+        required:
+        - spec
+        title: SupersetCluster
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/crd/supersetdb.crd.yaml
+++ b/deploy/crd/supersetdb.crd.yaml
@@ -13,48 +13,50 @@ spec:
     singular: supersetdb
   scope: Namespaced
   versions:
-    - additionalPrinterColumns: []
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "Auto-generated derived type for SupersetDBSpec via `CustomResource`"
-          properties:
-            spec:
-              properties:
-                credentialsSecret:
-                  type: string
-                loadExamples:
-                  type: boolean
-                supersetVersion:
-                  type: string
-              required:
-                - credentialsSecret
-                - loadExamples
-                - supersetVersion
-              type: object
-            status:
-              nullable: true
-              properties:
-                condition:
-                  enum:
-                    - Pending
-                    - Initializing
-                    - Ready
-                    - Failed
-                  type: string
-                startedAt:
-                  description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
-                  format: date-time
-                  nullable: true
-                  type: string
-              required:
-                - condition
-              type: object
-          required:
-            - spec
-          title: SupersetDB
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns: []
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for SupersetDBSpec via `CustomResource`
+        properties:
+          spec:
+            properties:
+              credentialsSecret:
+                type: string
+              loadExamples:
+                type: boolean
+              supersetVersion:
+                type: string
+            required:
+            - credentialsSecret
+            - loadExamples
+            - supersetVersion
+            type: object
+          status:
+            nullable: true
+            properties:
+              condition:
+                enum:
+                - Pending
+                - Initializing
+                - Ready
+                - Failed
+                type: string
+              startedAt:
+                description: Time is a wrapper around time.Time which supports correct
+                  marshaling to YAML and JSON.  Wrappers are provided for many of
+                  the factory methods that the time package offers.
+                format: date-time
+                nullable: true
+                type: string
+            required:
+            - condition
+            type: object
+        required:
+        - spec
+        title: SupersetDB
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/helm/superset-operator/crds/crds.yaml
+++ b/deploy/helm/superset-operator/crds/crds.yaml
@@ -20,7 +20,7 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: "Auto-generated derived type for SupersetClusterSpec via `CustomResource`"
+          description: Auto-generated derived type for SupersetClusterSpec via `CustomResource`
           properties:
             spec:
               properties:
@@ -33,18 +33,18 @@ spec:
                       type: string
                     syncRolesAt:
                       default: Registration
-                      description: "If we should replace ALL the user's roles each login, or only on registration. Gets mapped to `AUTH_ROLES_SYNC_AT_LOGIN`"
+                      description: If we should replace ALL the user's roles each login, or only on registration. Gets mapped to `AUTH_ROLES_SYNC_AT_LOGIN`
                       enum:
                         - Registration
                         - Login
                       type: string
                     userRegistration:
                       default: true
-                      description: "Allow users who are not already in the FAB DB. Gets mapped to `AUTH_USER_REGISTRATION`"
+                      description: Allow users who are not already in the FAB DB. Gets mapped to `AUTH_USER_REGISTRATION`
                       type: boolean
                     userRegistrationRole:
                       default: Public
-                      description: "This role will be given in addition to any AUTH_ROLES_MAPPING. Gets mapped to `AUTH_USER_REGISTRATION_ROLE`"
+                      description: This role will be given in addition to any AUTH_ROLES_MAPPING. Gets mapped to `AUTH_USER_REGISTRATION_ROLE`
                       type: string
                   type: object
                 credentialsSecret:
@@ -123,16 +123,16 @@ spec:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -144,7 +144,7 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                         type: object
@@ -156,7 +156,7 @@ spec:
                   nullable: true
                   type: string
                 stopped:
-                  description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
+                  description: Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)
                   nullable: true
                   type: boolean
                 version:
@@ -198,7 +198,7 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: "Auto-generated derived type for SupersetDBSpec via `CustomResource`"
+          description: Auto-generated derived type for SupersetDBSpec via `CustomResource`
           properties:
             spec:
               properties:
@@ -260,7 +260,7 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: "Auto-generated derived type for DruidConnectionSpec via `CustomResource`"
+          description: Auto-generated derived type for DruidConnectionSpec via `CustomResource`
           properties:
             spec:
               properties:

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -21,7 +21,7 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: "Auto-generated derived type for SupersetClusterSpec via `CustomResource`"
+          description: Auto-generated derived type for SupersetClusterSpec via `CustomResource`
           properties:
             spec:
               properties:
@@ -34,18 +34,18 @@ spec:
                       type: string
                     syncRolesAt:
                       default: Registration
-                      description: "If we should replace ALL the user's roles each login, or only on registration. Gets mapped to `AUTH_ROLES_SYNC_AT_LOGIN`"
+                      description: If we should replace ALL the user's roles each login, or only on registration. Gets mapped to `AUTH_ROLES_SYNC_AT_LOGIN`
                       enum:
                         - Registration
                         - Login
                       type: string
                     userRegistration:
                       default: true
-                      description: "Allow users who are not already in the FAB DB. Gets mapped to `AUTH_USER_REGISTRATION`"
+                      description: Allow users who are not already in the FAB DB. Gets mapped to `AUTH_USER_REGISTRATION`
                       type: boolean
                     userRegistrationRole:
                       default: Public
-                      description: "This role will be given in addition to any AUTH_ROLES_MAPPING. Gets mapped to `AUTH_USER_REGISTRATION_ROLE`"
+                      description: This role will be given in addition to any AUTH_ROLES_MAPPING. Gets mapped to `AUTH_USER_REGISTRATION_ROLE`
                       type: string
                   type: object
                 credentialsSecret:
@@ -124,16 +124,16 @@ spec:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values."
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist."
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -145,7 +145,7 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                         type: object
@@ -157,7 +157,7 @@ spec:
                   nullable: true
                   type: string
                 stopped:
-                  description: "Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)"
+                  description: Emergency stop button, if `true` then all pods are stopped without affecting configuration (as setting `replicas` to `0` would)
                   nullable: true
                   type: boolean
                 version:
@@ -199,7 +199,7 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: "Auto-generated derived type for SupersetDBSpec via `CustomResource`"
+          description: Auto-generated derived type for SupersetDBSpec via `CustomResource`
           properties:
             spec:
               properties:
@@ -261,7 +261,7 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: "Auto-generated derived type for DruidConnectionSpec via `CustomResource`"
+          description: Auto-generated derived type for DruidConnectionSpec via `CustomResource`
           properties:
             spec:
               properties:

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -10,6 +10,6 @@ version = "0.6.0-nightly"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.25.0" }
 strum = { version = "0.24", features = ["derive"] }
 snafu = "0.7"

--- a/rust/crd/src/druidconnection.rs
+++ b/rust/crd/src/druidconnection.rs
@@ -43,7 +43,7 @@ pub struct DruidConnectionSpec {
 
 impl DruidConnection {
     pub fn job_name(&self) -> String {
-        format!("{}-import", self.name())
+        format!("{}-import", self.name_unchecked())
     }
 
     pub fn superset_name(&self) -> String {
@@ -57,7 +57,7 @@ impl DruidConnection {
             Ok(ns)
         } else {
             NoNamespaceSnafu {
-                druid_connection: self.name(),
+                druid_connection: self.name_unchecked(),
             }
             .fail()
         }
@@ -74,7 +74,7 @@ impl DruidConnection {
             Ok(ns)
         } else {
             NoNamespaceSnafu {
-                druid_connection: self.name(),
+                druid_connection: self.name_unchecked(),
             }
             .fail()
         }

--- a/rust/crd/src/supersetdb.rs
+++ b/rust/crd/src/supersetdb.rs
@@ -55,7 +55,7 @@ impl SupersetDB {
             // when the cluster is created again.
             metadata: ObjectMetaBuilder::new()
                 .name_and_namespace(superset)
-                .with_recommended_labels(superset, APP_NAME, version, "", "") // TODO fill in missing fields
+                .with_recommended_labels(superset, APP_NAME, version, "", "", "") // TODO fill in missing fields
                 .build(),
             spec: SupersetDBSpec {
                 superset_version: version.to_string(),
@@ -67,7 +67,7 @@ impl SupersetDB {
     }
 
     pub fn job_name(&self) -> String {
-        self.name()
+        self.name_unchecked()
     }
 }
 

--- a/rust/crd/src/supersetdb.rs
+++ b/rust/crd/src/supersetdb.rs
@@ -6,6 +6,7 @@ use stackable_operator::k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
 use stackable_operator::k8s_openapi::chrono::Utc;
 use stackable_operator::kube::CustomResource;
 use stackable_operator::kube::ResourceExt;
+use stackable_operator::labels::{self, APP_VERSION_LABEL};
 use stackable_operator::schemars::{self, JsonSchema};
 
 #[derive(Snafu, Debug)]
@@ -49,13 +50,18 @@ impl SupersetDB {
             .version
             .as_deref()
             .context(NoSupersetVersionSnafu)?;
+
         Ok(Self {
             // The db is deliberately not owned by the cluster so it doesn't get deleted when the
             // cluster gets deleted.  The schema etc. still exists in the postgres db and can be reused
             // when the cluster is created again.
             metadata: ObjectMetaBuilder::new()
                 .name_and_namespace(superset)
-                .with_recommended_labels(superset, APP_NAME, version, "", "", "") // TODO fill in missing fields
+                .with_labels(labels::build_common_labels_for_all_managed_resources(
+                    &superset.name_any(),
+                    APP_NAME,
+                ))
+                .with_label(APP_VERSION_LABEL, version)
                 .build(),
             spec: SupersetDBSpec {
                 superset_version: version.to_string(),

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -13,9 +13,8 @@ clap = "3.2"
 fnv = "1.0"
 futures = { version = "0.3", features = ["compat"] }
 serde = "1.0"
-serde_yaml = "0.8"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.25.0" }
 stackable-superset-crd = { path = "../crd" }
 strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.20", features = ["macros", "rt-multi-thread"] }
@@ -23,5 +22,5 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.22.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.25.0" }
 stackable-superset-crd = { path = "../crd" }

--- a/rust/operator-binary/src/druid_connection_controller.rs
+++ b/rust/operator-binary/src/druid_connection_controller.rs
@@ -128,7 +128,7 @@ pub async fn reconcile_druid_connection(
                 }
                 // Is the referenced druid discovery configmap there?
                 let druid_discovery_cm_exists = client
-                    .exists::<ConfigMap>(
+                    .get_opt::<ConfigMap>(
                         &druid_connection.druid_name(),
                         Some(&druid_connection.druid_namespace().context(
                             DruidConnectionNoNamespaceSnafu {
@@ -137,7 +137,8 @@ pub async fn reconcile_druid_connection(
                         )?),
                     )
                     .await
-                    .context(DruidDiscoveryCheckSnafu)?;
+                    .context(DruidDiscoveryCheckSnafu)?
+                    .is_some();
 
                 if superset_db_ready && druid_discovery_cm_exists {
                     let superset_db = client
@@ -271,6 +272,7 @@ async fn build_import_job(
     let secret = &superset_db.spec.credentials_secret;
 
     let container = ContainerBuilder::new("superset-import-druid-connection")
+        .expect("ContainerBuilder not created")
         .image(format!(
             "docker.stackable.tech/stackable/superset:{}",
             superset_db.spec.superset_version


### PR DESCRIPTION
# Description

* Upgrade stackable-operator to version 0.25.0
* Delete orphaned resources

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
