### PR TITLE
[Merged by Bors] - test: Add readinessProbe to openldap to reduce test failures

### DIFF
--- a/tests/templates/kuttl/ldap/1-install-openldap.yaml
+++ b/tests/templates/kuttl/ldap/1-install-openldap.yaml
@@ -54,6 +54,9 @@ spec:
           volumeMounts:
             - name: tls
               mountPath: /tls
+          readinessProbe:
+            tcpSocket:
+              port: 1389
       volumes:
         - name: tls
           csi:


### PR DESCRIPTION
# Description

Should resolve
```
    logger.go:42: 01:46:20 | ldap_superset-1.3.2-stackable2.1.0_ldap-authentication-server-verification-tls/1-install-openldap | test step completed 1-install-openldap
    logger.go:42: 01:46:20 | ldap_superset-1.3.2-stackable2.1.0_ldap-authentication-server-verification-tls/2-create-ldap-user | starting test step 2-create-ldap-user
    logger.go:42: 01:46:20 | ldap_superset-1.3.2-stackable2.1.0_ldap-authentication-server-verification-tls/2-create-ldap-user | running command: [sh -c kubectl cp ./create_ldap_user.sh openldap-0:/tmp]
    logger.go:42: 01:46:20 | ldap_superset-1.3.2-stackable2.1.0_ldap-authentication-server-verification-tls/2-create-ldap-user | running command: [sh -c kubectl exec openldap-0 -- sh /tmp/create_ldap_user.sh]
    logger.go:42: 01:46:20 | ldap_superset-1.3.2-stackable2.1.0_ldap-authentication-server-verification-tls/2-create-ldap-user | ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)
    logger.go:42: 01:46:20 | ldap_superset-1.3.2-stackable2.1.0_ldap-authentication-server-verification-tls/2-create-ldap-user | ldap_sasl_bind(SIMPLE): Can't contact LDAP server (-1)
    logger.go:42: 01:46:20 | ldap_superset-1.3.2-stackable2.1.0_ldap-authentication-server-verification-tls/2-create-ldap-user | command terminated with exit code 255
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
