### PR TITLE
Add temporary attribute to support using ClusterIP instead of NodePort service type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add temporary attribute to support using ClusterIP instead of NodePort service type ([#266]).
+
 ### Changed
 
 - Include chart name when installing with a custom release name ([#227], [#228]).
@@ -13,6 +17,7 @@
 [#228]: https://github.com/stackabletech/superset-operator/pull/228
 [#247]: https://github.com/stackabletech/superset-operator/pull/247
 [#255]: https://github.com/stackabletech/superset-operator/pull/255
+[#266]: https://github.com/stackabletech/superset-operator/pull/266
 
 ## [0.5.0] - 2022-06-30
 

--- a/deploy/crd/supersetcluster.crd.yaml
+++ b/deploy/crd/supersetcluster.crd.yaml
@@ -198,6 +198,15 @@ spec:
                 required:
                 - roleGroups
                 type: object
+              serviceType:
+                description: Specify the type of the created kubernetes service. This
+                  attribute will be removed in a future release when listener-operator
+                  is finished. Use with caution.
+                enum:
+                - NodePort
+                - ClusterIP
+                nullable: true
+                type: string
               statsdExporterVersion:
                 nullable: true
                 type: string

--- a/deploy/helm/superset-operator/crds/crds.yaml
+++ b/deploy/helm/superset-operator/crds/crds.yaml
@@ -166,6 +166,13 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                serviceType:
+                  description: Specify the type of the created kubernetes service. This attribute will be removed in a future release when listener-operator is finished. Use with caution.
+                  enum:
+                    - NodePort
+                    - ClusterIP
+                  nullable: true
+                  type: string
                 statsdExporterVersion:
                   nullable: true
                   type: string

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -167,6 +167,13 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                serviceType:
+                  description: Specify the type of the created kubernetes service. This attribute will be removed in a future release when listener-operator is finished. Use with caution.
+                  enum:
+                    - NodePort
+                    - ClusterIP
+                  nullable: true
+                  type: string
                 statsdExporterVersion:
                   nullable: true
                   type: string

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -140,6 +140,25 @@ pub struct SupersetClusterSpec {
     pub authentication_config: Option<SupersetClusterAuthenticationConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nodes: Option<Role<SupersetConfig>>,
+    /// Specify the type of the created kubernetes service.
+    /// This attribute will be removed in a future release when listener-operator is finished.
+    /// Use with caution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_type: Option<ServiceType>,
+}
+
+// TODO: Temporary solution until listener-operator is finished
+#[derive(Clone, Debug, Display, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ServiceType {
+    NodePort,
+    ClusterIP,
+}
+
+impl Default for ServiceType {
+    fn default() -> Self {
+        Self::NodePort
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -344,7 +344,14 @@ fn build_node_role_service(superset: &SupersetCluster) -> Result<Service> {
                 ..ServicePort::default()
             }]),
             selector: Some(role_selector_labels(superset, APP_NAME, &role_name)),
-            type_: Some("NodePort".to_string()),
+            type_: Some(
+                superset
+                    .spec
+                    .service_type
+                    .clone()
+                    .unwrap_or_default()
+                    .to_string(),
+            ),
             ..ServiceSpec::default()
         }),
         status: None,


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/superset-operator/issues/264

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
