### PR TITLE
[Merged by Bors] - Upgrade stackable-operator to version 0.34.0 and bump images to 23.4.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Changed
 
+- `operator-rs` `0.31.0` -> `0.34.0` ([#322]).
+- Bumped stackable image versions to "23.4.0-rc1" ([#322]).
+
+[#322]: https://github.com/stackabletech/superset-operator/pull/322
+
+## [23.1.0] - 2023-01-23
+
+### Changed
+
 - `operator-rs` `0.27.1` -> `0.31.0` ([#306], [#297], [#311])
 - Fixed the RoleGroup `selector`. It was not used before. ([#306])
 - Updated stackable image versions ([#295]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.1"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -398,9 +398,9 @@ checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding"
@@ -535,9 +535,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -560,15 +560,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -577,15 +577,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -594,21 +594,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -951,7 +951,7 @@ dependencies = [
  "chrono",
  "dirs-next",
  "either",
- "futures 0.3.25",
+ "futures 0.3.26",
  "http",
  "http-body",
  "hyper",
@@ -1015,7 +1015,7 @@ dependencies = [
  "ahash",
  "backoff",
  "derivative",
- "futures 0.3.25",
+ "futures 0.3.26",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -1243,7 +1243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e785d273968748578931e4dc3b4f5ec86b26e09d9e0d66b55adda7fce742f7a"
 dependencies = [
  "async-trait",
- "futures 0.3.25",
+ "futures 0.3.26",
  "futures-executor",
  "once_cell",
  "opentelemetry",
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -1694,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.16"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1772,15 +1772,15 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.31.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.31.0#db959dbc83628be48c8e0706182e55f027f7b678"
+version = "0.34.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.34.0#c082c799d8598c8c7717406c025180d055027dd6"
 dependencies = [
  "chrono",
  "clap",
  "const_format",
  "derivative",
  "either",
- "futures 0.3.25",
+ "futures 0.3.26",
  "json-patch",
  "k8s-openapi",
  "kube",
@@ -1793,7 +1793,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml 0.9.16",
+ "serde_yaml 0.9.17",
  "snafu",
  "stackable-operator-derive",
  "strum",
@@ -1806,8 +1806,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.31.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.31.0#db959dbc83628be48c8e0706182e55f027f7b678"
+version = "0.34.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.34.0#c082c799d8598c8c7717406c025180d055027dd6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1835,7 +1835,7 @@ dependencies = [
  "built",
  "clap",
  "fnv",
- "futures 0.3.25",
+ "futures 0.3.26",
  "indoc",
  "serde",
  "snafu",
@@ -1962,9 +1962,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "libc",

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -21,7 +21,7 @@ metadata:
 spec:
   image:
     productVersion: 1.5.1
-    stackableVersion: 3.0.0
+    stackableVersion: 23.4.0-rc1
   [...]
   authenticationConfig:
     authenticationClass: ldap    # <1>

--- a/docs/modules/getting_started/examples/code/superset.yaml
+++ b/docs/modules/getting_started/examples/code/superset.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   image:
     productVersion: 1.5.1
-    stackableVersion: 3.0.0
+    stackableVersion: 23.4.0-rc1
   credentialsSecret: simple-superset-credentials
   loadExamplesOnInit: true
   nodes:

--- a/examples/superset-with-ldap.yaml
+++ b/examples/superset-with-ldap.yaml
@@ -150,7 +150,7 @@ metadata:
 spec:
   image:
     productVersion: 1.5.1
-    stackableVersion: 3.0.0
+    stackableVersion: 23.4.0-rc1
   credentialsSecret: superset-with-ldap-server-veri-tls-credentials
   nodes:
     roleGroups:

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.31.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.34.0" }
 strum = { version = "0.24", features = ["derive"] }
 snafu = "0.7"
 tracing = "0.1"

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -16,7 +16,7 @@ futures = { version = "0.3", features = ["compat"] }
 indoc = "1.0"
 serde = "1.0"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.31.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.34.0" }
 stackable-superset-crd = { path = "../crd" }
 strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.23", features = ["macros", "rt-multi-thread"] }
@@ -24,5 +24,5 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.31.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.34.0" }
 stackable-superset-crd = { path = "../crd" }

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,12 +2,12 @@
 dimensions:
   - name: superset
     values:
-      - 1.3.2-stackable3.0.0
-      - 1.4.1-stackable3.0.0
-      - 1.5.1-stackable3.0.0
+      - 1.3.2-stackable23.4.0-rc1
+      - 1.4.1-stackable23.4.0-rc1
+      - 1.5.1-stackable23.4.0-rc1
   - name: superset-latest
     values:
-      - 1.5.1-stackable3.0.0
+      - 1.5.1-stackable23.4.0-rc1
   - name: ldap-authentication
     values:
       - no-tls


### PR DESCRIPTION
# Description

Upgrade stackable-operator to version 0.34.0 and bump images to 23.4.0-rc1

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

Prerequisite for #317 

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
