### PR TITLE
[Merged by Bors] - Spike/docs testing

### DIFF
--- a/docs/modules/getting_started/examples/code/getting_started.sh
+++ b/docs/modules/getting_started/examples/code/getting_started.sh
@@ -14,6 +14,8 @@ then
   exit 1
 fi
 
+cd "$(dirname "$0")"
+
 case "$1" in
 "helm")
 echo "Adding 'stackable-dev' Helm Chart repository"

--- a/docs/modules/getting_started/examples/code/getting_started.sh
+++ b/docs/modules/getting_started/examples/code/getting_started.sh
@@ -69,9 +69,9 @@ kubectl apply -f superset.yaml
 
 echo "Waiting on SupersetDB ..."
 # tag::wait-supersetdb[]
-kubectl wait supersetdb/simple-superset \
+time kubectl wait supersetdb/simple-superset \
   --for jsonpath='{.status.condition}'=Ready \
-  --timeout 300s
+  --timeout 600s
 # end::wait-supersetdb[]
 
 sleep 5

--- a/docs/modules/getting_started/examples/code/getting_started.sh
+++ b/docs/modules/getting_started/examples/code/getting_started.sh
@@ -79,6 +79,9 @@ sleep 5
 echo "Wainting on superset StatefulSet ..."
 kubectl rollout status --watch statefulset/simple-superset-node-default
 
+# wait a bit for the port to open
+sleep 10
+
 echo "Starting port-forwarding of port 8088"
 # tag::port-forwarding[]
 kubectl port-forward service/simple-superset-external 8088 2>&1 >/dev/null &

--- a/docs/modules/getting_started/examples/code/getting_started.sh
+++ b/docs/modules/getting_started/examples/code/getting_started.sh
@@ -84,7 +84,7 @@ sleep 10
 
 echo "Starting port-forwarding of port 8088"
 # tag::port-forwarding[]
-kubectl port-forward service/simple-superset-external 8088 2>&1 >/dev/null &
+kubectl port-forward service/simple-superset-external 8088 > /dev/null 2>&1 &
 # end::port-forwarding[]
 PORT_FORWARD_PID=$!
 trap "kill $PORT_FORWARD_PID" EXIT

--- a/docs/modules/getting_started/examples/code/getting_started.sh.j2
+++ b/docs/modules/getting_started/examples/code/getting_started.sh.j2
@@ -14,6 +14,8 @@ then
   exit 1
 fi
 
+cd "$(dirname "$0")"
+
 case "$1" in
 "helm")
 echo "Adding '{{ helm.repo_name }}' Helm Chart repository"
@@ -67,9 +69,9 @@ kubectl apply -f superset.yaml
 
 echo "Waiting on SupersetDB ..."
 # tag::wait-supersetdb[]
-kubectl wait supersetdb/simple-superset \
+time kubectl wait supersetdb/simple-superset \
   --for jsonpath='{.status.condition}'=Ready \
-  --timeout 300s
+  --timeout 600s
 # end::wait-supersetdb[]
 
 sleep 5

--- a/docs/modules/getting_started/examples/code/getting_started.sh.j2
+++ b/docs/modules/getting_started/examples/code/getting_started.sh.j2
@@ -79,6 +79,9 @@ sleep 5
 echo "Wainting on superset StatefulSet ..."
 kubectl rollout status --watch statefulset/simple-superset-node-default
 
+# wait a bit for the port to open
+sleep 10
+
 echo "Starting port-forwarding of port 8088"
 # tag::port-forwarding[]
 kubectl port-forward service/simple-superset-external 8088 2>&1 >/dev/null &

--- a/docs/modules/getting_started/examples/code/getting_started.sh.j2
+++ b/docs/modules/getting_started/examples/code/getting_started.sh.j2
@@ -84,7 +84,7 @@ sleep 10
 
 echo "Starting port-forwarding of port 8088"
 # tag::port-forwarding[]
-kubectl port-forward service/simple-superset-external 8088 2>&1 >/dev/null &
+kubectl port-forward service/simple-superset-external 8088 > /dev/null 2>&1 &
 # end::port-forwarding[]
 PORT_FORWARD_PID=$!
 trap "kill $PORT_FORWARD_PID" EXIT

--- a/docs/modules/getting_started/examples/code/test_getting_started_helm.sh
+++ b/docs/modules/getting_started/examples/code/test_getting_started_helm.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+./getting_started.sh helm
+

--- a/docs/modules/getting_started/examples/code/test_getting_started_stackablectl.sh
+++ b/docs/modules/getting_started/examples/code/test_getting_started_stackablectl.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+./getting_started.sh stackablectl
+


### PR DESCRIPTION
# Description

Adds the two scripts used for testing.

Also increase a timeout because the test failed in azure. Example loading is really slow, I think it's because the load job has no requests. I made a ticket for it https://github.com/stackabletech/superset-operator/issues/324

While I looked at it, the CPU usage of the python load process was really high, so that's why I think it might be that.

https://ci.stackable.tech/view/05%20Documentation%20Tests/job/superset-operator-documentation-test/3/

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
