### PR TITLE
[Merged by Bors] - Added kuttl test suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@
 - `operator-rs` `0.40.2` -> `0.41.0` ([#360]).
 - Use 0.0.0-dev product images for testing ([#361])
 - Use testing-tools 0.2.0 ([#361])
+- Added kuttl test suites ([#373])
 
 [#360]: https://github.com/stackabletech/superset-operator/pull/360
 [#361]: https://github.com/stackabletech/superset-operator/pull/361
 [#362]: https://github.com/stackabletech/superset-operator/pull/362
 [#364]: https://github.com/stackabletech/superset-operator/pull/364
 [#367]: https://github.com/stackabletech/superset-operator/pull/367
+[#373]: https://github.com/stackabletech/superset-operator/pull/373
 
 ## [23.4.0] - 2023-04-17
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -48,3 +48,18 @@ tests:
     dimensions:
       - superset
       - openshift
+suites:
+  - name: latest
+    patch:
+      - dimensions:
+          - expr: last
+  - name: smoke
+    select:
+      - smoke
+  - name: openshift
+    patch:
+      - dimensions:
+          - expr: last
+      - dimensions:
+          - name: openshift
+            expr: "true"


### PR DESCRIPTION

# Description

Requires `beku 0.0.7`. Upgrade with:

```
pip install --upgrade beku-stackabletech
```

Added three test suites:

* `latest` : only run tests with the latest versions.
* `smoke` : only run smoke tests.
* `openshift` : only run latest versions with openshift=true.

To  run the `latest` test suite:

```
rm -rf tests/_work && beku -s latest
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Documentation added or updated
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
