### PR TITLE
Fix changelog and docs - mention removal of statsdExporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,10 @@
 
 - `operator-rs` `0.27.1` -> `0.31.0` ([#306], [#297], [#311])
 - Fixed the RoleGroup `selector`. It was not used before. ([#306])
-- Updated stackable image versions ([#295]).
-- [BREAKING] Use Product image selection instead of version. `spec.version` has been replaced by `spec.image` ([#304]).
+- Updated stackable image versions ([#295])
+- [BREAKING] Use Product image selection instead of version ([#304])
+  - `spec.version` has been replaced by `spec.image` 
+  - `spec.statsdExporterVersion` has been removed, the statsd-exporter is now part of the images itself
 - Refactored LDAP authentication handling to use functionality from the `LdapAuthenticationProvider` ([#311])
 
 [#306]: https://github.com/stackabletech/superset-operator/pull/306

--- a/docs/modules/superset/pages/getting_started/first_steps.adoc
+++ b/docs/modules/superset/pages/getting_started/first_steps.adoc
@@ -59,8 +59,6 @@ a list of available versions please check our
 https://repo.stackable.tech/#browse/browse:docker:v2%2Fstackable%2Fsuperset%2Ftags[image registry].
 It should generally be safe to simply use the latest image version that is available.
 
-`spec.statsdExporterVersion` must contain the tag of a statsd-exporter Docker image in the Stackable repository.
-
 The previously created secret must be referenced in `spec.credentialsSecret`.
 
 The `spec.loadExamplesOnInit` key is optional and defaults to `false`, it can be set to `true` to load example data into Superset when the database is initialized.
@@ -68,7 +66,7 @@ The `spec.loadExamplesOnInit` key is optional and defaults to `false`, it can be
 The `rowLimit` configuration option defines the row limit when requesting chart data.
 
 The `webserverTimeout` configuration option defines the maximum number of seconds a Superset request can take before timing out.
-This settings effect the maximum duration a query to an underlying datasource can take.
+These settings affect the maximum duration a query to an underlying datasource can take.
 If you get timeout errors before your query returns the result you may need to increase this timeout.
 
 === Initialization of the Superset database


### PR DESCRIPTION
# Description

We missed documenting that the statsd-exporter is now part of the images.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
