### PR TITLE
fix: Rename Service port name from `superset` to `http`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Fixed
 
-- BREAKING: Rename Service port name from `superset` to `http` for consistency reasons. This change should normally not be breaking, as we only change the name, not the port. However, there might be some e.g. Ingresses that rely on the port name and need to be updated. ([#394])
+- BREAKING: Rename Service port name from `superset` to `http` for consistency reasons. This change should normally not be breaking, as we only change the name, not the port. However, there might be some e.g. Ingresses that rely on the port name and need to be updated ([#394]).
 
 [#390]: https://github.com/stackabletech/superset-operator/pull/390
 [#391]: https://github.com/stackabletech/superset-operator/pull/391

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
 
 ### Fixed
 
-- Rename Service port name from `superset` to `http` for consistency reasons ([#XXX]).
+- BREAKING: Rename Service port name from `superset` to `http` for consistency reasons. This change should normally not be breaking, as we only change the name, not the port. However, there might be some e.g. Ingresses that rely on the port name and need to be updated. ([#394])
 
 [#390]: https://github.com/stackabletech/superset-operator/pull/390
 [#391]: https://github.com/stackabletech/superset-operator/pull/391
+[#394]: https://github.com/stackabletech/superset-operator/pull/394
 
 ## [23.7.0] - 2023-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - `vector` `0.26.0` -> `0.31.0` ([#391]).
 - `operator-rs` `0.44.0` -> `0.45.1` ([#390]).
 
+### Fixed
+
+- Rename Service port name from `superset` to `http` for consistency reasons ([#XXX]).
+
 [#390]: https://github.com/stackabletech/superset-operator/pull/390
 [#391]: https://github.com/stackabletech/superset-operator/pull/391
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -129,8 +129,6 @@ impl FlaskAppConfigOptions for SupersetConfigOptions {
     }
 }
 
-pub const HTTP_PORT: &str = "http";
-
 #[derive(Clone, CustomResource, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[kube(
     group = "superset.stackable.tech",

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -413,7 +413,7 @@ fn build_node_role_service(
                     .k8s_service_type(),
             ),
             ports: Some(vec![ServicePort {
-                name: Some("superset".to_string()),
+                name: Some("http".to_string()),
                 port: APP_PORT.into(),
                 protocol: Some("TCP".to_string()),
                 ..ServicePort::default()
@@ -525,7 +525,7 @@ fn build_node_rolegroup_service(
             cluster_ip: Some("None".to_string()),
             ports: Some(vec![
                 ServicePort {
-                    name: Some("superset".to_string()),
+                    name: Some("http".to_string()),
                     port: APP_PORT.into(),
                     protocol: Some("TCP".to_string()),
                     ..ServicePort::default()


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/superset-operator/issues/248


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
