### PR TITLE
Removed SupersetDB references in docs and RBAC config

### DIFF
--- a/deploy/helm/superset-operator/templates/roles.yaml
+++ b/deploy/helm/superset-operator/templates/roles.yaml
@@ -82,8 +82,6 @@ rules:
       - {{ include "operator.name" . }}clusters
       - druidconnections
       - druidconnections/status
-      - supersetdbs
-      - supersetdbs/status
     verbs:
       - get
       - list
@@ -95,13 +93,6 @@ rules:
       - {{ include "operator.name" . }}clusters/status
     verbs:
       - patch
-  # The operator creates the supersetdb for the cluster automatically
-  - apiGroups:
-      - {{ include "operator.name" . }}.stackable.tech
-    resources:
-      - supersetdbs
-    verbs:
-      - create
   - apiGroups:
       - authentication.stackable.tech
     resources:

--- a/docs/modules/superset/pages/index.adoc
+++ b/docs/modules/superset/pages/index.adoc
@@ -16,8 +16,8 @@ preloaded example data.
 
 == Resources
 
-The Operator manages three https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom
-resources]: The _SupersetCluster_, _SupersetDB_ and _DruidConnection_. It creates a number of different Kubernetes
+The Operator manages two https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[custom
+resources]: The _SupersetCluster_ and _DruidConnection_. It creates a number of different Kubernetes
 resources based on the custom resources.
 
 === Custom resources
@@ -27,11 +27,6 @@ xref:concepts:roles-and-role-groups.adoc[role], the `node`. The various configur
 xref:usage-guide/index.adoc[]. It helps you tune your cluster to your needs by configuring
 xref:usage-guide/storage-resource-configuration.adoc[resource usage], xref:usage-guide/security.adoc[security],
 xref:usage-guide/logging.adoc[logging] and more.
-
-When a SupersetCluster is first deployed, a SupersetDB resource is created. The SupersetDB resource is a wrapper
-resource for the SQL database that is used by Superset for its metadata. The resource contains some configuration but
-also keeps track of whether the database has been initialized or not. It is not deleted automatically if a
-SupersetCluster is deleted, and so can be reused.
 
 DruidConnection resources link a Superset and Druid instance. It lets you define this connection in the familiar way of
 deploying a resource (instead of configuring the connection via the Superset UI or API). The operator configures the
@@ -44,14 +39,14 @@ Based on the custom resources you define, the Operator creates ConfigMaps, State
 image::superset_overview.drawio.svg[A diagram depicting the Kubernetes resources created by the operator]
 
 The diagram above depicts all the Kubernetes resources created by the operator, and how they relate to each other. The
-Jobs created for the SupersetDB and DruidConnnection resources are not shown.
+Job created for the DruidConnnection resource is not shown.
 
 For every xref:concepts:roles-and-role-groups.adoc#_role_groups[role group] you define, the Operator creates a
 StatefulSet with the amount of replicas defined in the RoleGroup. Every Pod in the StatefulSet has two containers: the
 main container running Superset and a sidecar container gathering metrics for xref:operators:monitoring.adoc[]. The
 Operator creates a Service for the `node` role as well as a single service per role group.
 
-ConfigMaps are created, one per RoleGroup and also one for the SupersetDB. Both ConfigMaps contains two files:
+Additionally, a ConfigMap is created for each RoleGroup. These ConfigMaps contains two files:
 `log_config.py` and `superset_config.py` which contain logging and general Superset configuration respectively.
 
 == Required external component: Metastore SQL database


### PR DESCRIPTION
# Description

Cleanup, we forgot to remove those things in https://github.com/stackabletech/superset-operator/pull/396

Basically the same as https://github.com/stackabletech/airflow-operator/pull/331

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
