### PR TITLE
fix: Don't print Superset admin credentials during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't print Superset admin credentials during startup ([#483]).
+
+[#483]: https://github.com/stackabletech/superset-operator/pull/483
+
 ## [24.3.0] - 2024-03-20
 
 ### Added

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -742,7 +742,10 @@ fn build_server_rolegroup_statefulset(
             {auth_commands}
 
             superset db upgrade
+            # Don't print the following statement, as it contains credentials
+            set +x
             superset fab create-admin --username \"$ADMIN_USERNAME\" --firstname \"$ADMIN_FIRSTNAME\" --lastname \"$ADMIN_LASTNAME\" --email \"$ADMIN_EMAIL\" --password \"$ADMIN_PASSWORD\"
+            set -x
             superset init
             {COMMON_BASH_TRAP_FUNCTIONS}
 

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -742,8 +742,8 @@ fn build_server_rolegroup_statefulset(
             {auth_commands}
 
             superset db upgrade
-            # Don't print the following statement, as it contains credentials
             set +x
+            echo 'Running \"superset fab create-admin [...]\", which is not shown as it leaks the Superset admin credentials'
             superset fab create-admin --username \"$ADMIN_USERNAME\" --firstname \"$ADMIN_FIRSTNAME\" --lastname \"$ADMIN_LASTNAME\" --email \"$ADMIN_EMAIL\" --password \"$ADMIN_PASSWORD\"
             set -x
             superset init

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -733,39 +733,32 @@ fn build_server_rolegroup_statefulset(
             "-euo".to_string(),
             "pipefail".to_string(),
             "-c".to_string(),
-            formatdoc! {"
-                mkdir --parents {PYTHONPATH} && \
-                cp {STACKABLE_CONFIG_DIR}/* {PYTHONPATH} && \
-                cp {STACKABLE_LOG_CONFIG_DIR}/{LOG_CONFIG_FILE} {PYTHONPATH} && \
-                {auth_commands}
-                superset db upgrade && \
-                superset fab create-admin \
-                    --username \"$ADMIN_USERNAME\" \
-                    --firstname \"$ADMIN_FIRSTNAME\" \
-                    --lastname \"$ADMIN_LASTNAME\" \
-                    --email \"$ADMIN_EMAIL\" \
-                    --password \"$ADMIN_PASSWORD\" && \
-                superset init && \
-                {COMMON_BASH_TRAP_FUNCTIONS}
-                {remove_vector_shutdown_file_command}
-                prepare_signal_handlers
-                gunicorn \
-                --bind 0.0.0.0:${{SUPERSET_PORT}} \
-                --worker-class gthread \
-                --threads 20 \
-                --timeout {webserver_timeout} \
-                --limit-request-line 0 \
-                --limit-request-field_size 0 \
-                'superset.app:create_app()' &
-                wait_for_termination $!
-                {create_vector_shutdown_file_command}",
+        ])
+        .args(vec![formatdoc! {"
+            mkdir --parents {PYTHONPATH}
+            cp {STACKABLE_CONFIG_DIR}/* {PYTHONPATH}
+            cp {STACKABLE_LOG_CONFIG_DIR}/{LOG_CONFIG_FILE} {PYTHONPATH}
+
+            {auth_commands}
+
+            superset db upgrade
+            superset fab create-admin --username \"$ADMIN_USERNAME\" --firstname \"$ADMIN_FIRSTNAME\" --lastname \"$ADMIN_LASTNAME\" --email \"$ADMIN_EMAIL\" --password \"$ADMIN_PASSWORD\"
+            superset init
+            {COMMON_BASH_TRAP_FUNCTIONS}
+
+            {remove_vector_shutdown_file_command}
+            prepare_signal_handlers
+            gunicorn --bind 0.0.0.0:${{SUPERSET_PORT}} --worker-class gthread --threads 20 --timeout {webserver_timeout} --limit-request-line 0 --limit-request-field_size 0 'superset.app:create_app()' &
+            wait_for_termination $!
+
+            {create_vector_shutdown_file_command}
+        ",
             auth_commands = authentication_start_commands(authentication_config),
             remove_vector_shutdown_file_command =
                 remove_vector_shutdown_file_command(STACKABLE_LOG_DIR),
             create_vector_shutdown_file_command =
                 create_vector_shutdown_file_command(STACKABLE_LOG_DIR),
-            },
-        ])
+        }])
         .resources(merged_config.resources.clone().into());
     let probe = Probe {
         http_get: Some(HTTPGetAction {


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/internal-issues/issues/85

First commit is just making script better readable in k8s.
Actual fix is wrapping the command leaking the credentials with `set +x` and `set -x`.

Ideally we want a test for this, but I don't know how to test this (other than grepping for the password in the logs)

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [x] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
