### PR TITLE
fix: Entrypoint error when DB initialization fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 ### Fixed
 
 - Don't print Superset admin credentials during startup ([#483]).
-- Fix entrypoint to not throw `prepare_signal_handlers: command not found` in case DB initialization fails ([#XXX]).
+- Fix entrypoint to not throw `prepare_signal_handlers: command not found` in case DB initialization fails ([#485]).
 
 [#483]: https://github.com/stackabletech/superset-operator/pull/483
+[#485]: https://github.com/stackabletech/superset-operator/pull/485
 
 ## [24.3.0] - 2024-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Don't print Superset admin credentials during startup ([#483]).
+- Fix entrypoint to not throw `prepare_signal_handlers: command not found` in case DB initialization fails ([#XXX]).
 
 [#483]: https://github.com/stackabletech/superset-operator/pull/483
 

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -735,6 +735,8 @@ fn build_server_rolegroup_statefulset(
             "-c".to_string(),
         ])
         .args(vec![formatdoc! {"
+            {COMMON_BASH_TRAP_FUNCTIONS}
+
             mkdir --parents {PYTHONPATH}
             cp {STACKABLE_CONFIG_DIR}/* {PYTHONPATH}
             cp {STACKABLE_LOG_CONFIG_DIR}/{LOG_CONFIG_FILE} {PYTHONPATH}
@@ -747,7 +749,6 @@ fn build_server_rolegroup_statefulset(
             superset fab create-admin --username \"$ADMIN_USERNAME\" --firstname \"$ADMIN_FIRSTNAME\" --lastname \"$ADMIN_LASTNAME\" --email \"$ADMIN_EMAIL\" --password \"$ADMIN_PASSWORD\"
             set -x
             superset init
-            {COMMON_BASH_TRAP_FUNCTIONS}
 
             {remove_vector_shutdown_file_command}
             prepare_signal_handlers
@@ -794,6 +795,7 @@ fn build_server_rolegroup_statefulset(
         ])
         .args(vec![formatdoc! {"
             {COMMON_BASH_TRAP_FUNCTIONS}
+
             prepare_signal_handlers
             /stackable/statsd_exporter &
             wait_for_termination $!


### PR DESCRIPTION
# Description

When DB initialization fails for **some** reason `prepare_signal_handlers` get's called and errors. This is mostly a clean up change, as the Pod is crashlooping anyway :sweat_smile: It's just deflecting from the root cause.

```
k logs superset-node-default-0
Defaulted container "superset" out of: superset, metrics
+ mkdir --parents /stackable/app/pythonpath
+ cp /stackable/config/log_config.py /stackable/config/superset_config.py /stackable/app/pythonpath
+ cp /stackable/log_config/log_config.py /stackable/app/pythonpath
+ superset db upgrade
'FLASK_ENV' is deprecated and will not be used in Flask 2.3. Use 'FLASK_DEBUG' instead.
2024-04-19 17:33:25,373:INFO:root:Configured event logger of type <class 'superset.utils.log.DBEventLogger'>
2024-04-19 17:33:25,374:WARNING:superset.initialization:We haven't found any Content Security Policy (CSP) defined in the configurations. Please make sure to configure CSP using the TALISMAN_ENABLED and TALISMAN_CONFIG keys or any other external software. Failing to configure CSP have serious security implications. Check https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more information. You can disable this warning using the CONTENT_SECURITY_POLICY_WARNING key.
/stackable/app/lib64/python3.9/site-packages/flask_limiter/extension.py:293: UserWarning: Using the in-memory storage for tracking rate limits as no storage was explicitly specified. This is not recommended for production use. See: [https://flask-limiter.readthedocs.io#configuring-a-storage-backend](https://flask-limiter.readthedocs.io/#configuring-a-storage-backend) for documentation about configuring the storage backend.
  warnings.warn(
2024-04-19 17:33:25,384:ERROR:flask_appbuilder.security.sqla.manager:DB Creation and initialization failed: (psycopg2.OperationalError) connection to server at "postgresql-superset" (10.233.47.171), port 5432 failed: FATAL:  password authentication failed for user "superset"

(Background on this error at: https://sqlalche.me/e/14/e3q8)
Loaded your LOCAL configuration at [/stackable/app/pythonpath/superset_config.py]
+ rm -f /stackable/log/_vector/shutdown
+ prepare_signal_handlers
/bin/bash: line 32: prepare_signal_handlers: command not found
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
