### PR TITLE
test(kuttl): Remove the -o pipefail bash option

### DIFF
--- a/tests/templates/kuttl/smoke/31-assert.yaml
+++ b/tests/templates/kuttl/smoke/31-assert.yaml
@@ -7,8 +7,7 @@ commands:
   # Test envOverrides
   #
   - script: |
-      #!/usr/bin/env bash
-      set -euo pipefail
+      set -eu
 
       # Config Test Data
       SUPERSET_CONFIG=$(


### PR DESCRIPTION
Kuttl hard codes `sh -c`, instead of allowing alternative shells to be used.
For now, we need to drop the `-o pipefail` option.

See: https://github.com/kudobuilder/kuttl/issues/557

> [!NOTE]
> For zsh users, `sh` appears to just alias zsh, so locally `set -euo pipfail` worked fine.