### PR TITLE
update usage of DeserializsedGuard refs

### DIFF
--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -235,8 +235,8 @@ fn valid_druid_connection_namespace(
     let Ok(druid_connection) = &druid_connection.0 else {
         return false;
     };
-    druid_connection.druid_namespace().ok() == config_map.meta().namespace
-        && Some(druid_connection.druid_name()) == config_map.meta().name
+    druid_connection.druid_namespace().ok() == config_map.namespace()
+        && druid_connection.druid_name() == config_map.name_any()
 }
 
 fn valid_druid_job(
@@ -246,6 +246,6 @@ fn valid_druid_job(
     let Ok(druid_connection) = &druid_connection.0 else {
         return false;
     };
-    druid_connection.metadata.namespace == job.meta().namespace
-        && Some(druid_connection.job_name()) == job.meta().name
+    druid_connection.metadata.namespace == job.namespace()
+        && druid_connection.job_name() == job.name_any()
 }


### PR DESCRIPTION
# Description

Something went wrong here: https://github.com/stackabletech/superset-operator/pull/551

This fixes it.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
