### PR TITLE
Adds missing KUBERNETES_CLUSTER_DOMAIN environment variable to docs

### DIFF
--- a/docs/modules/superset/pages/reference/environment-variables.adoc
+++ b/docs/modules/superset/pages/reference/environment-variables.adoc
@@ -2,6 +2,36 @@
 
 This operator accepts the following environment variables:
 
+== KUBERNETES_CLUSTER_DOMAIN
+
+*Default value*: cluster.local
+
+*Required*: false
+
+*Multiple values*: false
+
+This instructs the operator, which value it should use for the Kubernetes `clusterDomain` setting.
+Make sure to keep this in sync with whatever setting your cluster uses.
+Please see the documentation xref:guides:kubernetes-cluster-domain.adoc[on configuring the Kubernetes cluster domain] for more information on this feature.
+
+[source]
+----
+export KUBERNETES_CLUSTER_DOMAIN=mycluster.local
+cargo run -- run
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name superset-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/superset-operator:latest
+----
 
 == PRODUCT_CONFIG
 
@@ -9,7 +39,7 @@ This operator accepts the following environment variables:
 
 *Required*: false
 
-*Multiple values:* false
+*Multiple values*: false
 
 [source]
 ----
@@ -35,7 +65,7 @@ docker run \
 
 *Required*: false
 
-*Multiple values:* false
+*Multiple values*: false
 
 The operator will **only** watch for resources in the provided namespace `test`:
 


### PR DESCRIPTION
# Description

Adds missing KUBERNETES_CLUSTER_DOMAIN environment variable to docs

part of stackabletech/issues#668