### PR TITLE
test: Bump vector to 0.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 - BREAKING: Inject the vector aggregator address into the vector config using the env var `VECTOR_AGGREGATOR_ADDRESS` instead
     of having the operator write it to the vector config ([#609]).
+- test: Bump to Vector `0.46.1` ([#628]).
 
 ### Fixed
 
@@ -30,6 +31,7 @@
 [#615]: https://github.com/stackabletech/superset-operator/pull/615
 [#617]: https://github.com/stackabletech/superset-operator/pull/617
 [#623]: https://github.com/stackabletech/superset-operator/pull/623
+[#628]: https://github.com/stackabletech/superset-operator/pull/628
 
 ## [25.3.0] - 2025-03-21
 

--- a/tests/templates/kuttl/logging/10-install-superset-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/10-install-superset-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install superset-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.39.0
+      --version 0.42.1
       --repo https://helm.vector.dev
       --values superset-vector-aggregator-values.yaml
 ---


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1085.

- Bump to Vector 0.46.1 in tests

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
