### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - test: Bump to Vector `0.46.1` ([#628]).
 - test: Bump OPA to `1.4.2` ([#631]).
 - Use versioned common structs ([#635]).
+- BREAKING: Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#637])
+  - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
+  - This is marked as breaking because tools and policies might exist, which require these fields to be set
 
 ### Fixed
 
@@ -38,6 +42,7 @@
 [#628]: https://github.com/stackabletech/superset-operator/pull/628
 [#631]: https://github.com/stackabletech/superset-operator/pull/631
 [#635]: https://github.com/stackabletech/superset-operator/pull/635
+[#637]: https://github.com/stackabletech/superset-operator/pull/637
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/druid_connection_controller.rs
+++ b/rust/operator-binary/src/druid_connection_controller.rs
@@ -344,12 +344,7 @@ async fn build_import_job(
             image_pull_secrets: resolved_product_image.pull_secrets.clone(),
             restart_policy: Some("Never".to_string()),
             service_account: Some(sa_name.to_string()),
-            security_context: Some(
-                PodSecurityContextBuilder::new()
-                    .run_as_user(1000)
-                    .run_as_group(0)
-                    .build(),
-            ),
+            security_context: Some(PodSecurityContextBuilder::new().build()),
             ..Default::default()
         }),
     };

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -755,8 +755,6 @@ fn build_server_rolegroup_statefulset(
         .image_pull_secrets_from_product_image(resolved_product_image)
         .security_context(
             PodSecurityContextBuilder::new()
-                .run_as_user(1000)
-                .run_as_group(0)
                 .fs_group(1000) // Needed for secret-operator
                 .build(),
         )


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [x] Changelog updated

### Acceptance

- [ ] Proper release label has been added
