### PR TITLE
Listener: Use headless and metrics service

### DIFF
--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -19,7 +19,7 @@ use stackable_operator::{
         fragment::{self, Fragment, ValidationError},
         merge::Merge,
     },
-    k8s_openapi::apimachinery::pkg::api::resource::Quantity,
+    k8s_openapi::{api::core::v1::ServicePort, apimachinery::pkg::api::resource::Quantity},
     kube::{CustomResource, ResourceExt, runtime::reflector::ObjectRef},
     memory::{BinaryMultiple, MemoryQuantity},
     product_config_utils::{self, Configuration},
@@ -32,7 +32,10 @@ use stackable_operator::{
 };
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 
-use crate::crd::v1alpha1::{SupersetConfigFragment, SupersetRoleConfig};
+use crate::{
+    crd::v1alpha1::{SupersetConfigFragment, SupersetRoleConfig},
+    listener::default_listener_class,
+};
 
 pub mod affinity;
 pub mod authentication;
@@ -48,9 +51,6 @@ pub const MAX_LOG_FILES_SIZE: MemoryQuantity = MemoryQuantity {
     value: 10.0,
     unit: BinaryMultiple::Mebi,
 };
-
-pub const LISTENER_VOLUME_NAME: &str = "listener";
-pub const LISTENER_VOLUME_DIR: &str = "/stackable/listener";
 
 pub const APP_PORT_NAME: &str = "http";
 pub const APP_PORT: u16 = 8088;
@@ -311,10 +311,6 @@ impl Default for v1alpha1::SupersetRoleConfig {
     }
 }
 
-fn default_listener_class() -> String {
-    "cluster-internal".to_string()
-}
-
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SupersetCredentials {
@@ -526,6 +522,43 @@ impl v1alpha1::SupersetCluster {
                 cluster_name = self.name_any()
             )),
         }
+    }
+
+    /// Set of functions to define service names on rolegroup level.
+    /// Headless service for cluster internal purposes only.
+    // TODO: Move to operator-rs
+    pub fn rolegroup_headless_service_name(
+        &self,
+        rolegroup: &RoleGroupRef<v1alpha1::SupersetCluster>,
+    ) -> String {
+        format!("{name}-headless", name = rolegroup.object_name())
+    }
+
+    /// Headless metrics service exposes Prometheus endpoint only
+    // TODO: Move to operator-rs
+    pub fn rolegroup_headless_metrics_service_name(
+        &self,
+        rolegroup: &RoleGroupRef<v1alpha1::SupersetCluster>,
+    ) -> String {
+        format!("{name}-metrics", name = rolegroup.object_name())
+    }
+
+    pub fn metrics_ports(&self) -> Vec<ServicePort> {
+        vec![ServicePort {
+            name: Some(METRICS_PORT_NAME.to_string()),
+            port: METRICS_PORT.into(),
+            protocol: Some("TCP".to_string()),
+            ..ServicePort::default()
+        }]
+    }
+
+    pub fn service_ports(&self) -> Vec<ServicePort> {
+        vec![ServicePort {
+            name: Some(APP_PORT_NAME.to_string()),
+            port: APP_PORT.into(),
+            protocol: Some("TCP".to_string()),
+            ..ServicePort::default()
+        }]
     }
 
     pub fn generic_role_config(&self, role: &SupersetRole) -> Option<GenericRoleConfig> {

--- a/rust/operator-binary/src/listener.rs
+++ b/rust/operator-binary/src/listener.rs
@@ -1,0 +1,61 @@
+use snafu::{ResultExt, Snafu};
+use stackable_operator::{builder::meta::ObjectMetaBuilder, crd::listener, kvp::ObjectLabels};
+
+use crate::crd::{APP_PORT, APP_PORT_NAME, v1alpha1};
+
+pub const LISTENER_VOLUME_NAME: &str = "listener";
+pub const LISTENER_VOLUME_DIR: &str = "/stackable/listener";
+
+#[derive(Snafu, Debug)]
+pub enum Error {
+    #[snafu(display("object is missing metadata to build owner reference"))]
+    ObjectMissingMetadataForOwnerRef {
+        source: stackable_operator::builder::meta::Error,
+    },
+    #[snafu(display("failed to build Metadata"))]
+    MetadataBuild {
+        source: stackable_operator::builder::meta::Error,
+    },
+}
+
+pub fn build_group_listener(
+    superset: &v1alpha1::SupersetCluster,
+    object_labels: ObjectLabels<v1alpha1::SupersetCluster>,
+    listener_class: String,
+    listener_group_name: String,
+) -> Result<listener::v1alpha1::Listener, Error> {
+    let metadata = ObjectMetaBuilder::new()
+        .name_and_namespace(superset)
+        .name(listener_group_name)
+        .ownerreference_from_resource(superset, None, Some(true))
+        .context(ObjectMissingMetadataForOwnerRefSnafu)?
+        .with_recommended_labels(object_labels)
+        .context(MetadataBuildSnafu)?
+        .build();
+
+    let spec = listener::v1alpha1::ListenerSpec {
+        class_name: Some(listener_class),
+        ports: Some(listener_ports()),
+        ..Default::default()
+    };
+
+    let listener = listener::v1alpha1::Listener {
+        metadata,
+        spec,
+        status: None,
+    };
+
+    Ok(listener)
+}
+
+pub fn listener_ports() -> Vec<listener::v1alpha1::ListenerPort> {
+    vec![listener::v1alpha1::ListenerPort {
+        name: APP_PORT_NAME.to_owned(),
+        port: APP_PORT.into(),
+        protocol: Some("TCP".to_owned()),
+    }]
+}
+
+pub fn default_listener_class() -> String {
+    "cluster-internal".to_string()
+}

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -42,6 +42,7 @@ mod config;
 mod controller_commons;
 mod crd;
 mod druid_connection_controller;
+mod listener;
 mod operations;
 mod product_logging;
 mod rbac;

--- a/rust/operator-binary/src/superset_controller.rs
+++ b/rust/operator-binary/src/superset_controller.rs
@@ -32,14 +32,12 @@ use stackable_operator::{
     },
     cluster_resources::{ClusterResourceApplyStrategy, ClusterResources},
     commons::{product_image_selection::ResolvedProductImage, rbac::build_rbac_resources},
-    crd::{authentication::oidc, listener},
+    crd::authentication::oidc,
     k8s_openapi::{
         DeepMerge,
         api::{
             apps::v1::{StatefulSet, StatefulSetSpec},
-            core::v1::{
-                ConfigMap, EnvVar, HTTPGetAction, Probe, Service, ServicePort, ServiceSpec,
-            },
+            core::v1::{ConfigMap, EnvVar, HTTPGetAction, Probe, Service, ServiceSpec},
         },
         apimachinery::pkg::{apis::meta::v1::LabelSelector, util::intstr::IntOrString},
     },
@@ -48,7 +46,7 @@ use stackable_operator::{
         core::{DeserializeGuard, error_boundary},
         runtime::controller::Action,
     },
-    kvp::{Label, Labels, ObjectLabels},
+    kvp::{Label, Labels},
     logging::controller::ReconcilerError,
     product_config_utils::{
         CONFIG_OVERRIDE_FILE_FOOTER_KEY, CONFIG_OVERRIDE_FILE_HEADER_KEY,
@@ -78,14 +76,15 @@ use crate::{
     config::{self, PYTHON_IMPORTS},
     controller_commons::{self, CONFIG_VOLUME_NAME, LOG_CONFIG_VOLUME_NAME, LOG_VOLUME_NAME},
     crd::{
-        APP_NAME, APP_PORT, APP_PORT_NAME, LISTENER_VOLUME_DIR, LISTENER_VOLUME_NAME, METRICS_PORT,
-        METRICS_PORT_NAME, PYTHONPATH, STACKABLE_CONFIG_DIR, STACKABLE_LOG_CONFIG_DIR,
-        STACKABLE_LOG_DIR, SUPERSET_CONFIG_FILENAME, SupersetConfigOptions, SupersetRole,
+        APP_NAME, APP_PORT, METRICS_PORT, METRICS_PORT_NAME, PYTHONPATH, STACKABLE_CONFIG_DIR,
+        STACKABLE_LOG_CONFIG_DIR, STACKABLE_LOG_DIR, SUPERSET_CONFIG_FILENAME,
+        SupersetConfigOptions, SupersetRole,
         authentication::{
             SupersetAuthenticationClassResolved, SupersetClientAuthenticationDetailsResolved,
         },
-        v1alpha1::{self, Container, SupersetCluster, SupersetClusterStatus, SupersetConfig},
+        v1alpha1::{Container, SupersetCluster, SupersetClusterStatus, SupersetConfig},
     },
+    listener::{LISTENER_VOLUME_DIR, LISTENER_VOLUME_NAME, build_group_listener},
     operations::{graceful_shutdown::add_graceful_shutdown_config, pdb::add_pdbs},
     product_logging::{LOG_CONFIG_FILE, extend_config_map_with_log_config},
     util::{build_recommended_labels, rolegroup_metrics_service_name},
@@ -298,6 +297,8 @@ pub enum Error {
     ApplyGroupListener {
         source: stackable_operator::cluster_resources::Error,
     },
+    #[snafu(display("failed to configure listener"))]
+    ListenerConfiguration { source: crate::listener::Error },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -410,8 +411,6 @@ pub async fn reconcile_superset(
             .merged_config(&SupersetRole::Node, &rolegroup)
             .context(FailedToResolveConfigSnafu)?;
 
-        let rg_service =
-            build_node_rolegroup_service(superset, &resolved_product_image, &rolegroup)?;
         let rg_configmap = build_rolegroup_config_map(
             superset,
             &resolved_product_image,
@@ -431,13 +430,16 @@ pub async fn reconcile_superset(
             &rbac_sa.name_any(),
             &config,
         )?;
-
-        cluster_resources
-            .add(client, rg_service)
-            .await
-            .with_context(|_| ApplyRoleGroupServiceSnafu {
-                rolegroup: rolegroup.clone(),
-            })?;
+        for rg_service in
+            build_node_rolegroup_services(superset, &resolved_product_image, &rolegroup)?
+        {
+            cluster_resources
+                .add(client, rg_service)
+                .await
+                .with_context(|_| ApplyRoleGroupServiceSnafu {
+                    rolegroup: rolegroup.clone(),
+                })?;
+        }
         cluster_resources
             .add(client, rg_configmap)
             .await
@@ -467,7 +469,8 @@ pub async fn reconcile_superset(
                 ),
                 listener_class.to_string(),
                 listener_group_name,
-            )?;
+            )
+            .context(ListenerConfigurationSnafu)?;
             cluster_resources
                 .add(client, group_listener)
                 .await
@@ -619,91 +622,88 @@ fn build_rolegroup_config_map(
 /// The rolegroup [`Service`] is a headless service that allows direct access to the instances of a certain rolegroup
 ///
 /// This is mostly useful for internal communication between peers, or for clients that perform client-side load balancing.
-fn build_node_rolegroup_service(
+fn build_node_rolegroup_services(
     superset: &SupersetCluster,
     resolved_product_image: &ResolvedProductImage,
     rolegroup: &RoleGroupRef<SupersetCluster>,
-) -> Result<Service> {
-    let metadata = ObjectMetaBuilder::new()
-        .name_and_namespace(superset)
-        .name(rolegroup_metrics_service_name(&rolegroup.object_name()))
-        .ownerreference_from_resource(superset, None, Some(true))
-        .context(ObjectMissingMetadataForOwnerRefSnafu)?
-        .with_recommended_labels(build_recommended_labels(
-            superset,
-            SUPERSET_CONTROLLER_NAME,
-            &resolved_product_image.app_version_label,
-            &rolegroup.role,
-            &rolegroup.role_group,
-        ))
-        .context(MetadataBuildSnafu)?
-        .with_label(Label::try_from(("prometheus.io/scrape", "true")).context(LabelBuildSnafu)?)
-        .build();
-
-    let spec = Some(ServiceSpec {
-        // Internal communication does not need to be exposed
-        type_: Some("ClusterIP".to_owned()),
-        cluster_ip: Some("None".to_owned()),
-        ports: Some(vec![ServicePort {
-            name: Some(METRICS_PORT_NAME.to_owned()),
-            port: METRICS_PORT.into(),
-            protocol: Some("TCP".to_owned()),
-            ..ServicePort::default()
-        }]),
-        selector: Some(
-            Labels::role_group_selector(superset, APP_NAME, &rolegroup.role, &rolegroup.role_group)
-                .context(LabelBuildSnafu)?
-                .into(),
-        ),
-        publish_not_ready_addresses: Some(true),
-        ..ServiceSpec::default()
-    });
-
-    let service = Service {
-        metadata,
-        spec,
-        status: None,
-    };
+) -> Result<Vec<Service>> {
+    let service = vec![
+        Service {
+            metadata: ObjectMetaBuilder::new()
+                .name_and_namespace(superset)
+                .name(superset.rolegroup_headless_metrics_service_name(&rolegroup))
+                .ownerreference_from_resource(superset, None, Some(true))
+                .context(ObjectMissingMetadataForOwnerRefSnafu)?
+                .with_recommended_labels(build_recommended_labels(
+                    superset,
+                    SUPERSET_CONTROLLER_NAME,
+                    &resolved_product_image.app_version_label,
+                    &rolegroup.role,
+                    &rolegroup.role_group,
+                ))
+                .context(MetadataBuildSnafu)?
+                .with_label(
+                    Label::try_from(("prometheus.io/scrape", "true")).context(LabelBuildSnafu)?,
+                )
+                .build(),
+            spec: Some(ServiceSpec {
+                // Internal communication does not need to be exposed
+                type_: Some("ClusterIP".to_owned()),
+                cluster_ip: Some("None".to_owned()),
+                ports: Some(superset.metrics_ports()),
+                selector: Some(
+                    Labels::role_group_selector(
+                        superset,
+                        APP_NAME,
+                        &rolegroup.role,
+                        &rolegroup.role_group,
+                    )
+                    .context(LabelBuildSnafu)?
+                    .into(),
+                ),
+                publish_not_ready_addresses: Some(true),
+                ..ServiceSpec::default()
+            }),
+            status: None,
+        },
+        Service {
+            metadata: ObjectMetaBuilder::new()
+                .name_and_namespace(superset)
+                .name(superset.rolegroup_headless_service_name(&rolegroup))
+                .ownerreference_from_resource(superset, None, Some(true))
+                .context(ObjectMissingMetadataForOwnerRefSnafu)?
+                .with_recommended_labels(build_recommended_labels(
+                    superset,
+                    SUPERSET_CONTROLLER_NAME,
+                    &resolved_product_image.app_version_label,
+                    &rolegroup.role,
+                    &rolegroup.role_group,
+                ))
+                .context(MetadataBuildSnafu)?
+                .build(),
+            spec: Some(ServiceSpec {
+                // Internal communication does not need to be exposed
+                type_: Some("ClusterIP".to_owned()),
+                cluster_ip: Some("None".to_owned()),
+                ports: Some(superset.service_ports()),
+                selector: Some(
+                    Labels::role_group_selector(
+                        superset,
+                        APP_NAME,
+                        &rolegroup.role,
+                        &rolegroup.role_group,
+                    )
+                    .context(LabelBuildSnafu)?
+                    .into(),
+                ),
+                publish_not_ready_addresses: Some(true),
+                ..ServiceSpec::default()
+            }),
+            status: None,
+        },
+    ];
 
     Ok(service)
-}
-
-pub fn build_group_listener(
-    superset: &v1alpha1::SupersetCluster,
-    object_labels: ObjectLabels<v1alpha1::SupersetCluster>,
-    listener_class: String,
-    listener_group_name: String,
-) -> Result<listener::v1alpha1::Listener> {
-    let metadata = ObjectMetaBuilder::new()
-        .name_and_namespace(superset)
-        .name(listener_group_name)
-        .ownerreference_from_resource(superset, None, Some(true))
-        .context(ObjectMissingMetadataForOwnerRefSnafu)?
-        .with_recommended_labels(object_labels)
-        .context(MetadataBuildSnafu)?
-        .build();
-
-    let spec = listener::v1alpha1::ListenerSpec {
-        class_name: Some(listener_class),
-        ports: Some(listener_ports()),
-        ..Default::default()
-    };
-
-    let listener = listener::v1alpha1::Listener {
-        metadata,
-        spec,
-        status: None,
-    };
-
-    Ok(listener)
-}
-
-fn listener_ports() -> Vec<listener::v1alpha1::ListenerPort> {
-    vec![listener::v1alpha1::ListenerPort {
-        name: APP_PORT_NAME.to_owned(),
-        port: APP_PORT.into(),
-        protocol: Some("TCP".to_owned()),
-    }]
 }
 
 /// The rolegroup [`StatefulSet`] runs the rolegroup, as configured by the administrator.


### PR DESCRIPTION
## Description

This PR adopts hive according to https://github.com/stackabletech/decisions/issues/54#issue-3110829918

Additionally this adds listener functions to listener.rs and moves service_ports() and metrics_ports() to SupersetCluster as a method.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
