### PR TITLE
fix(docs): Update getting-started script pre-25.7.0

### DIFF
--- a/docs/modules/superset/examples/getting_started/getting_started.sh
+++ b/docs/modules/superset/examples/getting_started/getting_started.sh
@@ -110,5 +110,5 @@ echo "Loading examples ..."
 # tag::load-examples[]
 kubectl apply -f superset-load-examples-job.yaml
 sleep 5
-kubectl wait --for=condition=complete --timeout=300s job/superset-load-examples
+kubectl wait --for=condition=complete --timeout=1500s job/superset-load-examples
 # end::load-examples[]

--- a/docs/modules/superset/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/superset/examples/getting_started/getting_started.sh.j2
@@ -110,5 +110,5 @@ echo "Loading examples ..."
 # tag::load-examples[]
 kubectl apply -f superset-load-examples-job.yaml
 sleep 5
-kubectl wait --for=condition=complete --timeout=300s job/superset-load-examples
+kubectl wait --for=condition=complete --timeout=1500s job/superset-load-examples
 # end::load-examples[]


### PR DESCRIPTION
Increase the timeout to 30 minutes for the superset-load-examples Job.
It can take up to 18 minutes (depending on external factors)

## Check and Update Getting Started Script

<!--
    Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-getting-started-scripts.md'
    when you rename this file.
-->

<!--
    Replace 'TRACKING_ISSUE' with the applicable release tracking issue number.
-->

Part of <https://github.com/stackabletech/issues/issues/742>

> [!NOTE]
> During a Stackable release we need to check (and optionally update) the
> getting-started scripts to ensure they still work after product and operator
> updates.

```shell
# Some of the scripts are in a code/ subdirectory
# pushd docs/modules/superset/examples/getting_started
# pushd docs/modules/superset/examples/getting_started/code
pushd $(fd -td getting_started | grep examples); cd code 2>/dev/null || true

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm

popd
```
