### PR TITLE
fix: Add RBAC permission to patch events

### DIFF
--- a/deploy/helm/superset-operator/templates/roles.yaml
+++ b/deploy/helm/superset-operator/templates/roles.yaml
@@ -165,6 +165,7 @@ rules:
       - events
     verbs:
       - create
+      - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   - apiGroups:
       - security.openshift.io


### PR DESCRIPTION
Needed since https://github.com/stackabletech/operator-rs/pull/938

Not 100% sure why the product needs this, but it was this way before.
