### PR TITLE
chore: update tests and docs to use bitnamilegacy

### DIFF
--- a/docs/modules/superset/examples/getting_started/getting_started.sh
+++ b/docs/modules/superset/examples/getting_started/getting_started.sh
@@ -52,6 +52,10 @@ echo "Installing bitnami PostgreSQL"
 # tag::install-bitnami-psql[]
 helm install superset oci://registry-1.docker.io/bitnamicharts/postgresql \
     --version 16.5.0 \
+    --set image.repository=bitnamilegacy/postgresql \
+    --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+    --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+    --set global.security.allowInsecureImages=true \
     --set auth.username=superset \
     --set auth.password=superset \
     --set auth.database=superset \

--- a/docs/modules/superset/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/superset/examples/getting_started/getting_started.sh.j2
@@ -52,6 +52,10 @@ echo "Installing bitnami PostgreSQL"
 # tag::install-bitnami-psql[]
 helm install superset oci://registry-1.docker.io/bitnamicharts/postgresql \
     --version 16.5.0 \
+    --set image.repository=bitnamilegacy/postgresql \
+    --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+    --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+    --set global.security.allowInsecureImages=true \
     --set auth.username=superset \
     --set auth.password=superset \
     --set auth.database=superset \

--- a/examples/superset-with-ldap.yaml
+++ b/examples/superset-with-ldap.yaml
@@ -1,6 +1,6 @@
 # helm install secret-operator oci://oci.stackable.tech/sdp-charts/secret-operator
 # helm install commons-operator oci://oci.stackable.tech/sdp-charts/commons-operator
-# helm install --repo https://charts.bitnami.com/bitnami --set auth.username=superset --set auth.password=superset --set auth.database=superset superset-postgresql postgresql
+# helm install --set auth.username=superset --set auth.password=superset --set auth.database=superset --set image.repository=bitnamilegacy/postgresql --set volumePermissions.image.repository=bitnamilegacy/os-shell --set metrics.image.repository=bitnamilegacy/postgres-exporter --set global.security.allowInsecureImages=true superset-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql
 
 # Log in with user01/user01 or user02/user02
 ---
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: openldap
-          image: docker.io/bitnami/openldap:2.5
+          image: docker.io/bitnamilegacy/openldap:2.5
           env:
             - name: LDAP_ADMIN_USERNAME
               value: admin

--- a/tests/templates/kuttl/cluster-operation/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/tests/templates/kuttl/druid-connection/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/druid-connection/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/tests/templates/kuttl/external-access/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/external-access/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/tests/templates/kuttl/ldap/20-install-openldap.yaml.j2
+++ b/tests/templates/kuttl/ldap/20-install-openldap.yaml.j2
@@ -46,7 +46,7 @@ commands:
               fsGroup: 1000
             containers:
               - name: openldap
-                image: docker.io/bitnami/openldap:2.5
+                image: docker.io/bitnamilegacy/openldap:2.5
                 env:
                   - name: LDAP_ADMIN_USERNAME
                     value: admin

--- a/tests/templates/kuttl/ldap/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/ldap/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/tests/templates/kuttl/logging/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/logging/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/tests/templates/kuttl/oidc/10_helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/oidc/10_helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/tests/templates/kuttl/opa/10_helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/opa/10_helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/tests/templates/kuttl/resources/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/resources/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:

--- a/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
+++ b/tests/templates/kuttl/smoke/helm-bitnami-postgresql-values.yaml.j2
@@ -1,8 +1,21 @@
 ---
+global:
+  security:
+    allowInsecureImages: true # needed starting with Chart version 16.3.0 if modifying images
+
+image:
+  repository: bitnamilegacy/postgresql
+
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
   securityContext:
     runAsUser: auto
+
+metrics:
+  image:
+    repository: bitnamilegacy/postgres-exporter
 
 primary:
   podSecurityContext:


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/749 Quickfix
This PR updates the tests and docs to use the bitnamylegacy repository for bitnami images. All affected tests, commands and getting started scripts ran successfully.

Integrationstests:
```
--- PASS: kuttl (347.04s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_superset-4.1.2_openshift-false (195.27s)
        --- PASS: kuttl/harness/smoke_superset-4.0.2_openshift-false (200.03s)
        --- PASS: kuttl/harness/smoke_superset-4.1.1_openshift-false (151.74s)
PASS

--- PASS: kuttl (90.74s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/resources_superset-latest-4.1.2_openshift-false (90.72s)
PASS

--- PASS: kuttl (476.04s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/opa_superset-4.0.2_opa-latest-1.4.2_openshift-false (234.70s)
        --- PASS: kuttl/harness/opa_superset-4.1.2_opa-latest-1.4.2_openshift-false (234.84s)
        --- PASS: kuttl/harness/opa_superset-4.1.1_opa-latest-1.4.2_openshift-false (241.33s)
PASS

--- PASS: kuttl (320.49s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/oidc_superset-4.1.2_openshift-false (165.86s)
        --- PASS: kuttl/harness/oidc_superset-4.0.2_openshift-false (166.14s)
        --- PASS: kuttl/harness/oidc_superset-4.1.1_openshift-false (154.63s)
PASS

--- PASS: kuttl (270.47s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_superset-4.0.2_openshift-false (139.00s)
        --- PASS: kuttl/harness/logging_superset-4.1.2_openshift-false (156.45s)
        --- PASS: kuttl/harness/logging_superset-4.1.1_openshift-false (131.45s)
PASS

--- PASS: kuttl (690.91s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/ldap_superset-4.0.2_ldap-authentication-insecure-tls_openshift-false (132.17s)
        --- PASS: kuttl/harness/ldap_superset-4.1.1_ldap-authentication-server-verification-tls_openshift-false (153.27s)
        --- PASS: kuttl/harness/ldap_superset-4.1.1_ldap-authentication-insecure-tls_openshift-false (136.64s)
        --- PASS: kuttl/harness/ldap_superset-4.1.1_ldap-authentication-no-tls_openshift-false (136.98s)
        --- PASS: kuttl/harness/ldap_superset-4.1.2_ldap-authentication-no-tls_openshift-false (136.79s)
        --- PASS: kuttl/harness/ldap_superset-4.1.2_ldap-authentication-server-verification-tls_openshift-false (254.79s)
        --- PASS: kuttl/harness/ldap_superset-4.0.2_ldap-authentication-server-verification-tls_openshift-false (145.24s)
        --- PASS: kuttl/harness/ldap_superset-4.0.2_ldap-authentication-no-tls_openshift-false (140.93s)
        --- PASS: kuttl/harness/ldap_superset-4.1.2_ldap-authentication-insecure-tls_openshift-false (140.05s)
PASS

--- PASS: kuttl (225.20s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/external-access_superset-4.0.2_openshift-false (113.77s)
        --- PASS: kuttl/harness/external-access_superset-4.1.2_openshift-false (115.62s)
        --- PASS: kuttl/harness/external-access_superset-4.1.1_openshift-false (111.41s)
PASS

--- PASS: kuttl (209.58s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/druid-connection_superset-4.0.2_openshift-false (103.61s)
        --- PASS: kuttl/harness/druid-connection_superset-4.1.1_openshift-false (102.52s)
        --- PASS: kuttl/harness/druid-connection_superset-4.1.2_openshift-false (209.56s)
PASS

--- PASS: kuttl (113.68s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_superset-latest-4.1.2_openshift-false (113.66s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
