### PR TITLE
chore: update docs and examples to use bitnamilegacy

### DIFF
--- a/docs/modules/superset/examples/getting_started/getting_started.sh
+++ b/docs/modules/superset/examples/getting_started/getting_started.sh
@@ -52,6 +52,10 @@ echo "Installing bitnami PostgreSQL"
 # tag::install-bitnami-psql[]
 helm install superset oci://registry-1.docker.io/bitnamicharts/postgresql \
     --version 16.5.0 \
+    --set image.repository=bitnamilegacy/postgresql \
+    --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+    --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+    --set global.security.allowInsecureImages=true \
     --set auth.username=superset \
     --set auth.password=superset \
     --set auth.database=superset \

--- a/docs/modules/superset/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/superset/examples/getting_started/getting_started.sh.j2
@@ -52,6 +52,10 @@ echo "Installing bitnami PostgreSQL"
 # tag::install-bitnami-psql[]
 helm install superset oci://registry-1.docker.io/bitnamicharts/postgresql \
     --version 16.5.0 \
+    --set image.repository=bitnamilegacy/postgresql \
+    --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+    --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+    --set global.security.allowInsecureImages=true \
     --set auth.username=superset \
     --set auth.password=superset \
     --set auth.database=superset \

--- a/examples/superset-with-ldap.yaml
+++ b/examples/superset-with-ldap.yaml
@@ -1,6 +1,6 @@
 # helm install secret-operator oci://oci.stackable.tech/sdp-charts/secret-operator
 # helm install commons-operator oci://oci.stackable.tech/sdp-charts/commons-operator
-# helm install --repo https://charts.bitnami.com/bitnami --set auth.username=superset --set auth.password=superset --set auth.database=superset superset-postgresql postgresql
+# helm install --set auth.username=superset --set auth.password=superset --set auth.database=superset --set image.repository=bitnamilegacy/postgresql --set volumePermissions.image.repository=bitnamilegacy/os-shell --set metrics.image.repository=bitnamilegacy/postgres-exporter --set global.security.allowInsecureImages=true superset-postgresql oci://registry-1.docker.io/bitnamicharts/postgresql
 
 # Log in with user01/user01 or user02/user02
 ---
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: openldap
-          image: docker.io/bitnami/openldap:2.5
+          image: docker.io/bitnamilegacy/openldap:2.5
           env:
             - name: LDAP_ADMIN_USERNAME
               value: admin


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/749 and follow up to https://github.com/stackabletech/superset-operator/pull/655
This PR updates the docs and examples of the 25.7 release to use bitnamilegacy.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
