### PR TITLE
feat: support setting clientAuthenticationMethod for OIDC

### DIFF
--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -244,6 +244,14 @@ fn append_oidc_config(
                 let well_known_config_url = oidc
                     .well_known_config_url()
                     .context(InvalidWellKnownConfigUrlSnafu)?;
+                let client_auth_method = serde_json::to_value(
+                    client_options.client_authentication_method,
+                )
+                .expect("ClientAuthenticationMethod should serialize to JSON");
+                let client_auth_method = client_auth_method
+                    .as_str()
+                    .expect("ClientAuthenticationMethod should serialize to a string");
+
                 formatdoc!(
                     "
                       {{ 'name': 'keycloak',
@@ -257,6 +265,7 @@ fn append_oidc_config(
                           }},
                           'api_base_url': '{api_base_url}',
                           'server_metadata_url': '{well_known_config_url}',
+                          'token_endpoint_auth_method': '{client_auth_method}',
                         }},
                       }}",
                     scopes = scopes.join(" "),
@@ -340,6 +349,7 @@ mod tests {
         let oidc = oidc::v1alpha1::ClientAuthenticationOptions {
             client_credentials_secret_ref: "nifi-keycloak-client".to_owned(),
             extra_scopes: vec![],
+            client_authentication_method: Default::default(),
             product_specific_fields: (),
         };
 
@@ -357,6 +367,7 @@ mod tests {
         assert!(oauth_providers.contains("client_id': os.environ.get("));
         assert!(oauth_providers.contains("client_secret': os.environ.get("));
         assert!(oauth_providers.contains("'scope': 'openid'"));
+        assert!(oauth_providers.contains("'token_endpoint_auth_method': 'client_secret_basic'"));
         assert!(oauth_providers.contains(&format!("'api_base_url': '{expected_api_base_url}'")));
         assert!(oauth_providers.contains(&format!(
             "'server_metadata_url': '{expected_server_metadata_url}'"

--- a/rust/operator-binary/src/crd/authentication.rs
+++ b/rust/operator-binary/src/crd/authentication.rs
@@ -486,6 +486,7 @@ mod tests {
                         client_auth_options: oidc::v1alpha1::ClientAuthenticationOptions {
                             client_credentials_secret_ref: "superset-oidc-client1".into(),
                             extra_scopes: vec!["groups".into()],
+                            client_authentication_method: Default::default(),
                             product_specific_fields: ()
                         }
                     },
@@ -502,6 +503,7 @@ mod tests {
                         client_auth_options: oidc::v1alpha1::ClientAuthenticationOptions {
                             client_credentials_secret_ref: "superset-oidc-client2".into(),
                             extra_scopes: Vec::new(),
+                            client_authentication_method: Default::default(),
                             product_specific_fields: ()
                         }
                     }


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/838

The `clientAuthenticationMethod` field from the OIDC `ClientAuthenticationOptions` is currently deserialized but never used. This PR passes it through to the generated `superset_config.py` as `token_endpoint_auth_method`.

I tested it in a Kind cluster with our Keycloak setup from the OIDC integration test (by setting the client authentication method to `private_key_jwt` instead of `client_secret_basic`, then OIDC login failed, as expected).

Requires an operator-rs release with stackabletech/operator-rs#1178.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
