### PR TITLE
chore!: Rename EXPERIMENTAL_FILE_HEADER / EXPERIMENTAL_FILE_FOOTER in superset_config.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@
 - BREAKING: `configOverrides` now only accepts the supported config file name `superset_config.py`. Previously arbitrary keys were silently accepted but ignored ([#719]).
 - Bump `stackable-operator` to 0.110.0 and `kube` to 3.1.0 ([#719]).
 - Support setting `clientAuthenticationMethod` for OIDC authentication. The value is passed through to the Flask-AppBuilder config as `token_endpoint_auth_method` ([#719]).
-- BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `superset_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([]).
+- BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `superset_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([#721]).
 
 [#717]: https://github.com/stackabletech/superset-operator/pull/717
 [#719]: https://github.com/stackabletech/superset-operator/pull/719
+[#721]: https://github.com/stackabletech/superset-operator/pull/721
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - BREAKING: `configOverrides` now only accepts the supported config file name `superset_config.py`. Previously arbitrary keys were silently accepted but ignored ([#719]).
 - Bump `stackable-operator` to 0.110.0 and `kube` to 3.1.0 ([#719]).
 - Support setting `clientAuthenticationMethod` for OIDC authentication. The value is passed through to the Flask-AppBuilder config as `token_endpoint_auth_method` ([#719]).
-- BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `superset_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([#721]).
+- BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `superset_config.py` for arbitrary Python code to `FILE_HEADER` and `FILE_FOOTER`  ([#719], [#721]).
 
 [#717]: https://github.com/stackabletech/superset-operator/pull/717
 [#719]: https://github.com/stackabletech/superset-operator/pull/719

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - BREAKING: `configOverrides` now only accepts the supported config file name `superset_config.py`. Previously arbitrary keys were silently accepted but ignored ([#719]).
 - Bump `stackable-operator` to 0.110.0 and `kube` to 3.1.0 ([#719]).
 - Support setting `clientAuthenticationMethod` for OIDC authentication. The value is passed through to the Flask-AppBuilder config as `token_endpoint_auth_method` ([#719]).
+- BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `superset_config.py` for arbitrary python code to `FILE_HEADER` and `FILE_FOOTER`  ([]).
 
 [#717]: https://github.com/stackabletech/superset-operator/pull/717
 [#719]: https://github.com/stackabletech/superset-operator/pull/719

--- a/docs/modules/superset/pages/usage-guide/configuration-environment-overrides.adoc
+++ b/docs/modules/superset/pages/usage-guide/configuration-environment-overrides.adoc
@@ -59,7 +59,7 @@ For a full list of configuration options we refer to the
 https://github.com/apache/superset/blob/master/superset/config.py[main config file for Superset].
 
 As Superset can be configured with python code too, arbitrary code can be added to the `superset_conf.py`.
-You can use either `EXPERIMENTAL_FILE_HEADER` to add code to the top or `EXPERIMENTAL_FILE_FOOTER` to add to the bottom.
+You can use either `FILE_HEADER` to add code to the top or `FILE_FOOTER` to add to the bottom.
 
 IMPORTANT: This is an experimental feature
 
@@ -69,9 +69,9 @@ nodes:
   configOverrides:
     superset_config.py:
       CSV_EXPORT: "{'encoding': 'utf-8'}"
-      EXPERIMENTAL_FILE_HEADER: |
+      FILE_HEADER: |
         from modules.my_module import my_class
-      EXPERIMENTAL_FILE_FOOTER: |
+      FILE_FOOTER: |
         import logging
         from superset.security import SupersetSecurityManager
 

--- a/tests/templates/kuttl/smoke/30-install-superset.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-install-superset.yaml.j2
@@ -46,17 +46,17 @@ spec:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     configOverrides:
       superset_config.py:
-        EXPERIMENTAL_FILE_HEADER: |
+        FILE_HEADER: |
           COMMON_HEADER_VAR = "role-value"
           ROLE_HEADER_VAR = "role-value"
-        EXPERIMENTAL_FILE_FOOTER: |
+        FILE_FOOTER: |
           ROLE_FOOTER_VAR = "role-value"
     roleGroups:
       default:
         replicas: 1
         configOverrides:
           superset_config.py:
-            EXPERIMENTAL_FILE_HEADER: |
+            FILE_HEADER: |
               COMMON_HEADER_VAR = "group-value"
         envOverrides:
           COMMON_VAR: group-value # overrides role value

--- a/tests/templates/kuttl/smoke/31-assert.yaml
+++ b/tests/templates/kuttl/smoke/31-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 600
+timeout: 300
 commands:
   #
   # Test envOverrides
@@ -16,9 +16,9 @@ commands:
       )
 
       # Config Test Assertions
-      echo "$SUPERSET_CONFIG" | grep 'COMMON_HEADER_VAR = "group-value"'
-      echo "$SUPERSET_CONFIG" | grep 'ROLE_FOOTER_VAR = "role-value"'
-      echo "$SUPERSET_CONFIG" | grep -v 'ROLE_HEADER_VAR = "role-value"'
+      echo "$SUPERSET_CONFIG" | grep '^COMMON_HEADER_VAR = "group-value"'
+      echo "$SUPERSET_CONFIG" | grep '^ROLE_FOOTER_VAR = "role-value"'
+      echo "$SUPERSET_CONFIG" | grep -v '^ROLE_HEADER_VAR = "role-value"'
 
       # STS Spec Test Data
       SUPERSET_NODE_DEFAULT_STS=$(kubectl -n "$NAMESPACE" get sts superset-node-default -o yaml)


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/836

- Removes `EXPERIMENTAL_` prefix from documentation and test
- Adjust test to actually catch the proper setting of the header / footer
- Add Changelog entry (actual removal of prefix was done in https://github.com/stackabletech/operator-rs/pull/1191)

### Integrationtests

```
--- PASS: kuttl (110.06s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_superset-6.0.0_openshift-false (99.81s)
        --- PASS: kuttl/harness/smoke_superset-4.1.4_openshift-false (110.05s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
