### PR TITLE
test: Bump Superset to 6.1.0 in unit test

### DIFF
--- a/rust/operator-binary/src/crd/affinity.rs
+++ b/rust/operator-binary/src/crd/affinity.rs
@@ -44,7 +44,7 @@ mod tests {
           name: simple-superset
         spec:
           image:
-            productVersion: 4.1.4
+            productVersion: 6.1.0
           clusterConfig:
             credentialsSecretName: superset-admin-credentials
             metadataDatabase:


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1504.