### PR TITLE
fix: Correctly migrate `SECRET_KEY` from 26.3 setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 - Support setting `clientAuthenticationMethod` for OIDC authentication. The value is passed through to the Flask-AppBuilder config as `token_endpoint_auth_method` ([#719]).
 - BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `superset_config.py` for arbitrary Python code to `FILE_HEADER` and `FILE_FOOTER`  ([#719], [#721]).
 - Use an internal Secret for the Superset `SECRET_KEY`.
-  Going forward, the operator will automatically create the Secret in case it doesn't exist ([#722], [#754]).
+  Going forward, the operator will automatically create the Secret in case it doesn't exist.
+  If your `credentialsSecret` at the time of upgrading points at a Secret with `connection.secretKey`, we  will automatically migrate your existing `SECRET_KEY` to avoid interruptions ([#722], [#754]).
 - BREAKING: Implement generic database connection.
   This means you need to replace your simple database connection string with a typed struct.
   This struct is consistent between different CRDs, so that you can easily copy/paste it between stacklets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,11 @@
 - Support setting `clientAuthenticationMethod` for OIDC authentication. The value is passed through to the Flask-AppBuilder config as `token_endpoint_auth_method` ([#719]).
 - BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `superset_config.py` for arbitrary Python code to `FILE_HEADER` and `FILE_FOOTER`  ([#719], [#721]).
 - Use an internal Secret for the Superset `SECRET_KEY`.
-  Going forward, the operator will automatically create the Secret in case it doesn't exist ([#722]).
-- BREAKING: The `.clusterConfig.credentialsSecret` field has been renamed to `.clusterConfig.credentialsSecretName` for consistency ([#722]).
+  Going forward, the operator will automatically create the Secret in case it doesn't exist ([#722], [#XXX]).
 - BREAKING: Implement generic database connection.
   This means you need to replace your simple database connection string with a typed struct.
   This struct is consistent between different CRDs, so that you can easily copy/paste it between stacklets.
-  More information can be found in the [Superset database documentation](https://docs.stackable.tech/home/nightly/superset/usage-guide/database-connections) for details ([#722]).
+  More information can be found in the [Superset database documentation](https://docs.stackable.tech/home/nightly/superset/usage-guide/database-connections) for details ([#722], [#XXX]).
 - Internal operator refactoring: introduce dereference() and validate() steps in the reconciler ([#731]).
 - test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC call ([#735]).
 - BREAKING: Removed product-config machinery. This is a breaking change in terms of configuration.
@@ -39,6 +38,7 @@
 [#735]: https://github.com/stackabletech/superset-operator/pull/735
 [#738]: https://github.com/stackabletech/superset-operator/pull/738
 [#751]: https://github.com/stackabletech/superset-operator/pull/751
+[#XXX]: https://github.com/stackabletech/superset-operator/pull/XXX
 
 ## [26.3.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@
 - Support setting `clientAuthenticationMethod` for OIDC authentication. The value is passed through to the Flask-AppBuilder config as `token_endpoint_auth_method` ([#719]).
 - BREAKING: Rename `EXPERIMENTAL_FILE_HEADER` and `EXPERIMENTAL_FILE_FOOTER` in `superset_config.py` for arbitrary Python code to `FILE_HEADER` and `FILE_FOOTER`  ([#719], [#721]).
 - Use an internal Secret for the Superset `SECRET_KEY`.
-  Going forward, the operator will automatically create the Secret in case it doesn't exist ([#722], [#XXX]).
+  Going forward, the operator will automatically create the Secret in case it doesn't exist ([#722], [#754]).
 - BREAKING: Implement generic database connection.
   This means you need to replace your simple database connection string with a typed struct.
   This struct is consistent between different CRDs, so that you can easily copy/paste it between stacklets.
-  More information can be found in the [Superset database documentation](https://docs.stackable.tech/home/nightly/superset/usage-guide/database-connections) for details ([#722], [#XXX]).
+  More information can be found in the [Superset database documentation](https://docs.stackable.tech/home/nightly/superset/usage-guide/database-connections) for details ([#722], [#754]).
 - Internal operator refactoring: introduce dereference() and validate() steps in the reconciler ([#731]).
 - test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC call ([#735]).
 - BREAKING: Removed product-config machinery. This is a breaking change in terms of configuration.
@@ -38,7 +38,7 @@
 [#735]: https://github.com/stackabletech/superset-operator/pull/735
 [#738]: https://github.com/stackabletech/superset-operator/pull/738
 [#751]: https://github.com/stackabletech/superset-operator/pull/751
-[#XXX]: https://github.com/stackabletech/superset-operator/pull/XXX
+[#754]: https://github.com/stackabletech/superset-operator/pull/754
 
 ## [26.3.0] - 2026-03-16
 

--- a/docs/modules/superset/examples/getting_started/superset.yaml
+++ b/docs/modules/superset/examples/getting_started/superset.yaml
@@ -15,7 +15,7 @@ spec:
   image:
     productVersion: 6.1.0
   clusterConfig:
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/extra/crds.yaml
+++ b/extra/crds.yaml
@@ -1023,7 +1023,7 @@ spec:
                           and `stopped` will take no effect until `reconciliationPaused` is set to false or removed.
                         type: boolean
                     type: object
-                  credentialsSecretName:
+                  credentialsSecret:
                     description: |-
                       The name of the Secret object containing the admin user credentials.
                       Read the
@@ -1108,7 +1108,7 @@ spec:
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                 required:
-                - credentialsSecretName
+                - credentialsSecret
                 - metadataDatabase
                 type: object
               image:

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -482,7 +482,7 @@ pub enum Error {
         source: stackable_operator::builder::meta::Error,
     },
 
-    #[snafu(display("failed to create SECRET_KEY secret from migrated value "))]
+    #[snafu(display("failed to create SECRET_KEY secret from migrated value"))]
     CreateRandomSecret {
         source: stackable_operator::client::Error,
     },

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -553,6 +553,9 @@ pub async fn reconcile_superset(
         .await
         .context(ApplyRoleBindingSnafu)?;
 
+    // TODO: Can be removed after SDP 26.7 is released (it's only a migration from 26.3 - 26.7)
+    // (don't forget about the snafu Error variants).
+    // Removal is tracked in https://github.com/stackabletech/superset-operator/issues/755
     migrate_legacy_secret_key_secret_from_26_3(superset, &validated, client).await?;
     create_random_secret_if_not_exists(
         &validated.cluster_config.secret_key_secret_name,

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -713,7 +713,8 @@ pub async fn reconcile_superset(
 }
 
 // TODO: Can be removed after SDP 26.7 is released (it's only a migration from 26.3 - 26.7)
-// (don't forget about the snafu Error variants)
+// (don't forget about the snafu Error variants).
+// Removal is tracked in https://github.com/stackabletech/superset-operator/issues/755
 #[instrument(skip_all)]
 async fn migrate_legacy_secret_key_secret_from_26_3(
     superset: &SupersetCluster,

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -9,6 +9,7 @@ use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     builder::meta::ObjectMetaBuilder,
     cli::OperatorEnvironmentOptions,
+    client::Client,
     cluster_resources::ClusterResourceApplyStrategy,
     commons::{
         affinity::StackableAffinity,
@@ -17,6 +18,7 @@ use stackable_operator::{
         rbac::build_rbac_resources,
         resources::{NoRuntimeLimits, Resources},
     },
+    k8s_openapi::api::core::v1::Secret,
     kube::{
         Resource, ResourceExt,
         api::ObjectMeta,
@@ -48,6 +50,7 @@ use stackable_operator::{
     },
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
+use tracing::instrument;
 
 use crate::{
     OPERATOR_NAME,
@@ -467,6 +470,22 @@ pub enum Error {
     CreateSecretKeySecret {
         source: random_secret_creation::Error,
     },
+
+    #[snafu(display("failed to retrieve credentials secret {secret_name:?}"))]
+    RetrieveCredentialsSecret {
+        source: stackable_operator::client::Error,
+        secret_name: String,
+    },
+
+    #[snafu(display("object is missing metadata to build owner reference"))]
+    ObjectMissingMetadataForOwnerRef {
+        source: stackable_operator::builder::meta::Error,
+    },
+
+    #[snafu(display("failed to create SECRET_KEY secret from migrated value "))]
+    CreateRandomSecret {
+        source: stackable_operator::client::Error,
+    },
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
@@ -534,6 +553,7 @@ pub async fn reconcile_superset(
         .await
         .context(ApplyRoleBindingSnafu)?;
 
+    migrate_legacy_secret_key_secret_from_26_3(superset, &validated, client).await?;
     create_random_secret_if_not_exists(
         &validated.cluster_config.secret_key_secret_name,
         INTERNAL_SECRET_SECRET_KEY,
@@ -690,6 +710,71 @@ pub async fn reconcile_superset(
         .context(ApplyStatusSnafu)?;
 
     Ok(Action::await_change())
+}
+
+// TODO: Can be removed after SDP 26.7 is released (it's only a migration from 26.3 - 26.7)
+// (don't forget about the snafu Error variants)
+#[instrument(skip_all)]
+async fn migrate_legacy_secret_key_secret_from_26_3(
+    superset: &SupersetCluster,
+    validated: &ValidatedCluster,
+    client: &Client,
+) -> Result<()> {
+    let old_secret_name = &validated.cluster_config.credentials_secret_name;
+    let new_secret_name = &validated.cluster_config.secret_key_secret_name;
+    let secret_namespace = &validated.namespace;
+
+    let new_secret = client
+        .get_opt::<Secret>(new_secret_name, secret_namespace.as_ref())
+        .await
+        .with_context(|_| RetrieveCredentialsSecretSnafu {
+            secret_name: new_secret_name,
+        })?;
+    if new_secret.is_some() {
+        tracing::debug!("SECRET_KEY Secret already exists, nothing to migrate");
+        return Ok(());
+    }
+
+    let old_secret = client
+        .get_opt::<Secret>(old_secret_name, secret_namespace.as_ref())
+        .await
+        .with_context(|_| RetrieveCredentialsSecretSnafu {
+            secret_name: old_secret_name,
+        })?;
+    let old_secret_key = old_secret
+        .and_then(|secret| secret.data)
+        // Note: We remove the key to take ownership
+        .and_then(|mut data| data.remove("connections.secretKey"))
+        .and_then(|key| String::from_utf8(key.0).ok());
+    if let Some(old_secret_key) = old_secret_key {
+        tracing::info!(
+            old.secret.name = old_secret_name,
+            old.secret.namespace = %secret_namespace,
+            new.secret.name = new_secret_name,
+            new.secret.namespace = %secret_namespace,
+            "Migrating old SECRET_KEY to new Secret"
+        );
+
+        let secret = Secret {
+            metadata: ObjectMetaBuilder::new()
+                .name(new_secret_name)
+                .namespace(secret_namespace)
+                .ownerreference_from_resource(superset, None, Some(true))
+                .context(ObjectMissingMetadataForOwnerRefSnafu)?
+                .build(),
+            string_data: Some(BTreeMap::from([(
+                INTERNAL_SECRET_SECRET_KEY.to_string(),
+                old_secret_key,
+            )])),
+            ..Secret::default()
+        };
+        client
+            .create(&secret)
+            .await
+            .context(CreateRandomSecretSnafu)?;
+    }
+
+    Ok(())
 }
 
 pub fn error_policy(

--- a/rust/operator-binary/src/controller/build/resource/config_map.rs
+++ b/rust/operator-binary/src/controller/build/resource/config_map.rs
@@ -99,7 +99,7 @@ mod tests {
           image:
             productVersion: 4.1.4
           clusterConfig:
-            credentialsSecretName: superset-admin-credentials
+            credentialsSecret: superset-admin-credentials
             metadataDatabase:
               postgresql:
                 host: superset-postgresql

--- a/rust/operator-binary/src/controller/validate.rs
+++ b/rust/operator-binary/src/controller/validate.rs
@@ -207,7 +207,7 @@ pub fn validate_cluster(
         ValidatedClusterConfig {
             authentication_config,
             opa_config,
-            credentials_secret_name: cluster_config.credentials_secret_name.clone(),
+            credentials_secret_name: cluster_config.credentials_secret.clone(),
             secret_key_secret_name: superset.shared_secret_key_secret_name(),
             mapbox_secret: cluster_config.mapbox_secret.clone(),
             metadata_database: cluster_config.metadata_database.clone(),
@@ -342,7 +342,7 @@ mod tests {
           image:
             productVersion: 4.1.4
           clusterConfig:
-            credentialsSecretName: superset-admin-credentials
+            credentialsSecret: superset-admin-credentials
             metadataDatabase:
               postgresql:
                 host: superset-postgresql
@@ -399,7 +399,7 @@ mod tests {
           image:
             productVersion: 4.1.4
           clusterConfig:
-            credentialsSecretName: superset-admin-credentials
+            credentialsSecret: superset-admin-credentials
             metadataDatabase:
               postgresql:
                 host: superset-postgresql

--- a/rust/operator-binary/src/controller/validate.rs
+++ b/rust/operator-binary/src/controller/validate.rs
@@ -207,7 +207,7 @@ pub fn validate_cluster(
         ValidatedClusterConfig {
             authentication_config,
             opa_config,
-            credentials_secret_name: cluster_config.credentials_secret.clone(),
+            credentials_secret_name: cluster_config.credentials_secret_name.clone(),
             secret_key_secret_name: superset.shared_secret_key_secret_name(),
             mapbox_secret: cluster_config.mapbox_secret.clone(),
             metadata_database: cluster_config.metadata_database.clone(),

--- a/rust/operator-binary/src/crd/affinity.rs
+++ b/rust/operator-binary/src/crd/affinity.rs
@@ -48,7 +48,7 @@ mod tests {
           image:
             productVersion: 6.1.0
           clusterConfig:
-            credentialsSecretName: superset-admin-credentials
+            credentialsSecret: superset-admin-credentials
             metadataDatabase:
               postgresql:
                 host: superset-postgresql

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -245,7 +245,8 @@ pub mod versioned {
         /// [getting started guide first steps](DOCS_BASE_URL_PLACEHOLDER/superset/getting_started/first_steps)
         /// to find out more.
         // TODO: In the future rename this to `credentialsSecretName`
-        pub credentials_secret: String,
+        #[serde(rename = "credentialsSecret")]
+        pub credentials_secret_name: String,
 
         /// Cluster operations like pause reconciliation or cluster stop.
         #[serde(default)]

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -244,7 +244,8 @@ pub mod versioned {
         /// Read the
         /// [getting started guide first steps](DOCS_BASE_URL_PLACEHOLDER/superset/getting_started/first_steps)
         /// to find out more.
-        pub credentials_secret_name: String,
+        // TODO: In the future rename this to `credentialsSecretName`
+        pub credentials_secret: String,
 
         /// Cluster operations like pause reconciliation or cluster stop.
         #[serde(default)]
@@ -615,7 +616,7 @@ mod tests {
                   reconciliationPaused: false
                   stopped: true
                 clusterConfig:
-                  credentialsSecretName: superset-admin-credentials
+                  credentialsSecret: superset-admin-credentials
                   metadataDatabase:
                     postgresql:
                       host: superset-postgresql

--- a/tests/templates/kuttl/celery-worker/40-install-superset.yaml.j2
+++ b/tests/templates/kuttl/celery-worker/40-install-superset.yaml.j2
@@ -47,7 +47,7 @@ spec:
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/cluster-operation/20-install-superset.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/20-install-superset.yaml.j2
@@ -39,7 +39,7 @@ spec:
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/druid-connection/20-install-superset.yaml.j2
+++ b/tests/templates/kuttl/druid-connection/20-install-superset.yaml.j2
@@ -39,7 +39,7 @@ spec:
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/external-access/install-superset.yaml.j2
+++ b/tests/templates/kuttl/external-access/install-superset.yaml.j2
@@ -33,7 +33,7 @@ spec:
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/ldap/50-install-superset.yaml.j2
+++ b/tests/templates/kuttl/ldap/50-install-superset.yaml.j2
@@ -53,7 +53,7 @@ spec:
       {%- endif %}
 
         userRegistrationRole: Admin
-    credentialsSecretName: superset-with-ldap-admin-credentials
+    credentialsSecret: superset-with-ldap-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/logging/21-install-superset.yaml.j2
+++ b/tests/templates/kuttl/logging/21-install-superset.yaml.j2
@@ -67,7 +67,7 @@ spec:
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/oidc/40_install-superset.yaml.j2
+++ b/tests/templates/kuttl/oidc/40_install-superset.yaml.j2
@@ -57,7 +57,7 @@ spec:
       - authenticationClass: keycloak2-$NAMESPACE
         oidc:
           clientCredentialsSecret: superset-keycloak2-client
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/opa/40_superset.yaml.j2
+++ b/tests/templates/kuttl/opa/40_superset.yaml.j2
@@ -38,7 +38,7 @@ spec:
       roleMappingFromOpa:
         configMapName: opa
         package: superset
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/resources/20-install-superset.yaml.j2
+++ b/tests/templates/kuttl/resources/20-install-superset.yaml.j2
@@ -37,7 +37,7 @@ spec:
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/smoke/30-install-superset.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-install-superset.yaml.j2
@@ -39,7 +39,7 @@ spec:
 {% endif %}
     pullPolicy: IfNotPresent
   clusterConfig:
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql

--- a/tests/templates/kuttl/upgrade/40_install-superset.yaml.j2
+++ b/tests/templates/kuttl/upgrade/40_install-superset.yaml.j2
@@ -50,7 +50,7 @@ spec:
         oidc:
           clientCredentialsSecret: superset-keycloak1-client
 {% endif %}
-    credentialsSecretName: superset-admin-credentials
+    credentialsSecret: superset-admin-credentials
     metadataDatabase:
       postgresql:
         host: superset-postgresql


### PR DESCRIPTION
## Description

Fixes https://github.com/stackabletech/superset-operator/issues/753

We basically lookup `connection.secretKey` from the old credentials Secret and use that as the `SECRET_KEY`. If - for some reason, e.g. fresh setup - it doesn't exist we still create a random value (as we currently do)

We had to revert the `credentialsSecret` -> `credentialsSecretName` rename, as otherwise the operator would reconcile the CRD on startup. This would in turn result in the `credentialsSecret` being dropped, so we loos the information how the old Secret was called.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added -> In https://github.com/stackabletech/superset-operator/pull/722#issuecomment-4709166856

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
