### PR TITLE
fix: add celery worker / beat to nav.adoc (#767)

### DIFF
--- a/docs/modules/superset/partials/nav.adoc
+++ b/docs/modules/superset/partials/nav.adoc
@@ -5,6 +5,7 @@
 * xref:superset:usage-guide/index.adoc[]
 ** xref:superset:usage-guide/listenerclass.adoc[]
 ** xref:superset:usage-guide/storage-resource-configuration.adoc[]
+** xref:superset:usage-guide/celery-async-queries.adoc[]
 ** xref:superset:usage-guide/database-connections.adoc[]
 ** xref:superset:usage-guide/security.adoc[]
 ** xref:superset:usage-guide/connecting-druid.adoc[]


### PR DESCRIPTION
## Description

Backport of #767 to `release-26.7`.

Cherry-picks 5855ff5 which adds the Celery worker / beat entries to the
docs navigation (`docs/modules/superset/partials/nav.adoc`).

Applied cleanly with no conflicts (1 file changed, 1 insertion).

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
