### PR TITLE
fix: Add missing owns/watches and test early-exit reconcile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 - Fix a longstanding problem of including empty `categories`, `shortNames` and `additionalPrinterColumns` in the CRDs,
   which could cause problems with GitOps tools (e.g. ArgoCD) reporting a diff in the custom resources.
   See [our internal issue](https://github.com/stackabletech/hdfs-operator/issues/626) and [the fix](https://github.com/kube-rs/kube/pull/2042) for details ([#773]).
+- The operator now watches all resources that it creates and early-exits the reconcile action when the
+  cluster is marked for deletion ([#781]).
 
 [#756]: https://github.com/stackabletech/superset-operator/pull/756
 [#761]: https://github.com/stackabletech/superset-operator/pull/761
@@ -44,6 +46,7 @@
 [#772]: https://github.com/stackabletech/superset-operator/pull/772
 [#773]: https://github.com/stackabletech/superset-operator/pull/773
 [#779]: https://github.com/stackabletech/superset-operator/pull/779
+[#781]: https://github.com/stackabletech/superset-operator/pull/781
 
 ## [26.7.0] - 2026-07-21
 

--- a/deploy/helm/superset-operator/templates/clusterrole-operator.yaml
+++ b/deploy/helm/superset-operator/templates/clusterrole-operator.yaml
@@ -13,15 +13,17 @@ rules:
       - nodes/proxy
     verbs:
       - get
-  # Manage core namespaced resources created per SupersetCluster.
-  # All resources are applied via Server-Side Apply (create + patch) and tracked for
-  # orphan cleanup (list + delete). ReconciliationPaused uses get.
-  # Secrets are needed for auto-generated SECRET_KEY (random_secret_creation).
+  # Manage core namespaced resources created per SupersetCluster (the ServiceAccount is
+  # also created per DruidConnection and provides workload pod identity).
+  # All resources are applied via Server-Side Apply (create + patch), tracked for
+  # orphan cleanup (list + delete) and watched by the controller. ReconciliationPaused
+  # uses get. Secrets are needed for auto-generated SECRET_KEY (random_secret_creation).
   - apiGroups:
       - ""
     resources:
       - configmaps
       - secrets
+      - serviceaccounts
       - services
     verbs:
       - create
@@ -30,20 +32,9 @@ rules:
       - list
       - patch
       - watch
-  # ServiceAccount created per SupersetCluster and per DruidConnection.
-  # Applied via SSA and tracked for orphan cleanup.
-  - apiGroups:
-      - ""
-    resources:
-      - serviceaccounts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
   # RoleBinding created per SupersetCluster to bind the product ClusterRole to the workload
-  # ServiceAccount. Applied via SSA and tracked for orphan cleanup.
+  # ServiceAccount. Applied via SSA and tracked for orphan cleanup and watched by the
+  # controller.
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -54,6 +45,7 @@ rules:
       - get
       - list
       - patch
+      - watch
   # Required to bind the product ClusterRole to the per-cluster ServiceAccount.
   - apiGroups:
       - rbac.authorization.k8s.io
@@ -98,7 +90,8 @@ rules:
       - list
       - patch
       - watch
-  # PodDisruptionBudget created per role. Applied via SSA and tracked for orphan cleanup.
+  # PodDisruptionBudget created per role. Applied via SSA and tracked for orphan cleanup
+  # and watched by the controller.
   - apiGroups:
       - policy
     resources:
@@ -109,6 +102,7 @@ rules:
       - get
       - list
       - patch
+      - watch
   # Required for maintaining the CRDs within the operator (including the conversion webhook info).
   # Also for the startup condition check before the controller can run.
   - apiGroups:
@@ -167,7 +161,7 @@ rules:
       - list
       - watch
   # Listener created per role group for external access. Applied via SSA and tracked for orphan
-  # cleanup.
+  # cleanup and watched by the controller.
   - apiGroups:
       - listeners.stackable.tech
     resources:
@@ -178,3 +172,4 @@ rules:
       - get
       - list
       - patch
+      - watch

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -363,6 +363,10 @@ pub async fn reconcile_superset(
 ) -> Result<Action> {
     tracing::info!("Starting reconcile");
 
+    if superset.meta().deletion_timestamp.is_some() {
+        return Ok(Action::await_change());
+    }
+
     let superset = superset
         .0
         .as_ref()
@@ -454,7 +458,16 @@ pub(crate) mod test_support {
 
 #[cfg(test)]
 mod controller_tests {
-    use super::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME};
+    use std::str::FromStr;
+
+    use stackable_operator::{
+        client::Client,
+        commons::networking::DomainName,
+        kube::{Client as KubeClient, Config},
+        utils::cluster_info::KubernetesClusterInfo,
+    };
+
+    use super::{CONTROLLER_NAME, OPERATOR_NAME, PRODUCT_NAME, *};
 
     #[test]
     fn test_constants() {
@@ -462,5 +475,55 @@ mod controller_tests {
         let _ = *PRODUCT_NAME;
         let _ = *OPERATOR_NAME;
         let _ = *CONTROLLER_NAME;
+    }
+
+    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
+    /// proves that a cluster being deleted returns before the reconciler touches the Kubernetes
+    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    #[test]
+    fn reconcile_exits_early_for_deleted_cluster() {
+        let superset = serde_yaml::from_str(
+            r#"
+apiVersion: superset.stackable.tech/v1alpha1
+kind: SupersetCluster
+metadata:
+  name: superset
+  namespace: default
+  deletionTimestamp: "2026-08-14T12:00:00Z"
+spec: {}
+"#,
+        )
+        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
+
+        let action = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread tokio runtime")
+            .block_on(async {
+                let ctx = Arc::new(Ctx {
+                    client: Client::new(
+                        KubeClient::try_from(Config::new(
+                            "http://127.0.0.1:1".parse().expect("valid static URI"),
+                        ))
+                        .expect("client from static config"),
+                        None,
+                        "default".to_owned(),
+                        KubernetesClusterInfo {
+                            cluster_domain: DomainName::from_str("cluster.local")
+                                .expect("valid cluster domain"),
+                        },
+                    ),
+                    operator_environment: OperatorEnvironmentOptions {
+                        operator_namespace: "stackable-operators".to_owned(),
+                        operator_service_name: "superset-operator".to_owned(),
+                        image_repository: "oci.stackable.tech/sdp".to_owned(),
+                    },
+                });
+
+                reconcile_superset(Arc::new(superset), ctx).await
+            })
+            .expect("a deleted cluster reconciles without any API call");
+
+        assert_eq!(action, Action::await_change());
     }
 }

--- a/rust/operator-binary/src/druid_connection_controller/mod.rs
+++ b/rust/operator-binary/src/druid_connection_controller/mod.rs
@@ -17,7 +17,7 @@ use stackable_operator::{
         core::v1::{ConfigMap, EnvVar, EnvVarSource, PodSpec, PodTemplateSpec, SecretKeySelector},
     },
     kube::{
-        ResourceExt,
+        Resource, ResourceExt,
         core::{DeserializeGuard, DynamicObject, error_boundary},
         runtime::{controller::Action, reflector::ObjectRef},
     },
@@ -153,6 +153,10 @@ pub async fn reconcile_druid_connection(
     ctx: Arc<Ctx>,
 ) -> Result<Action> {
     tracing::info!("Starting reconciling DruidConnections");
+
+    if druid_connection.meta().deletion_timestamp.is_some() {
+        return Ok(Action::await_change());
+    }
 
     let druid_connection = druid_connection
         .0
@@ -457,9 +461,63 @@ pub fn error_policy(
 
 #[cfg(test)]
 mod tests {
-    use stackable_operator::utils::yaml_from_str_singleton_map;
+    use stackable_operator::{
+        commons::networking::DomainName,
+        kube::{Client as KubeClient, Config},
+        utils::{cluster_info::KubernetesClusterInfo, yaml_from_str_singleton_map},
+    };
 
     use super::*;
+
+    /// The client points at a closed port, so any API call would fail the reconciliation: an `Ok`
+    /// proves that a connection being deleted returns before the reconciler touches the Kubernetes
+    /// API, and because the spec is invalid, before the [`DeserializeGuard`] is unwrapped.
+    #[test]
+    fn reconcile_exits_early_for_deleted_connection() {
+        let druid_connection = serde_yaml::from_str(
+            r#"
+apiVersion: superset.stackable.tech/v1alpha1
+kind: DruidConnection
+metadata:
+  name: simple-connection
+  namespace: default
+  deletionTimestamp: "2026-08-14T12:00:00Z"
+spec: {}
+"#,
+        )
+        .expect("YAML parses; the invalid spec is captured inside the DeserializeGuard");
+
+        let action = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread tokio runtime")
+            .block_on(async {
+                let ctx = Arc::new(Ctx {
+                    client: Client::new(
+                        KubeClient::try_from(Config::new(
+                            "http://127.0.0.1:1".parse().expect("valid static URI"),
+                        ))
+                        .expect("client from static config"),
+                        None,
+                        "default".to_owned(),
+                        KubernetesClusterInfo {
+                            cluster_domain: DomainName::from_str("cluster.local")
+                                .expect("valid cluster domain"),
+                        },
+                    ),
+                    operator_environment: OperatorEnvironmentOptions {
+                        operator_namespace: "stackable-operators".to_owned(),
+                        operator_service_name: "superset-operator".to_owned(),
+                        image_repository: "oci.stackable.tech/sdp".to_owned(),
+                    },
+                });
+
+                reconcile_druid_connection(Arc::new(druid_connection), ctx).await
+            })
+            .expect("a deleted connection reconciles without any API call");
+
+        assert_eq!(action, Action::await_change());
+    }
 
     #[test]
     fn test_constants() {

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -9,12 +9,14 @@ use futures::{FutureExt, StreamExt, TryFutureExt};
 use stackable_operator::{
     YamlSchema,
     cli::{Command, RunArguments},
-    crd::authentication::core,
+    crd::{authentication::core, listener},
     eos::EndOfSupportChecker,
     k8s_openapi::api::{
         apps::v1::{Deployment, StatefulSet},
         batch::v1::Job,
-        core::v1::{ConfigMap, Service},
+        core::v1::{ConfigMap, Service, ServiceAccount},
+        policy::v1::PodDisruptionBudget,
+        rbac::v1::RoleBinding,
     },
     kube::{
         CustomResourceExt as _, ResourceExt,
@@ -135,16 +137,37 @@ async fn main() -> anyhow::Result<()> {
             let config_map_store = superset_controller.store();
             let superset_controller = superset_controller
                 .owns(
-                    watch_namespace.get_api::<DeserializeGuard<Service>>(&client),
-                    watcher::Config::default(),
-                )
-                .owns(
-                    watch_namespace.get_api::<DeserializeGuard<StatefulSet>>(&client),
+                    watch_namespace.get_api::<DeserializeGuard<ConfigMap>>(&client),
                     watcher::Config::default(),
                 )
                 // Required for workers and beat.
                 .owns(
                     watch_namespace.get_api::<DeserializeGuard<Deployment>>(&client),
+                    watcher::Config::default(),
+                )
+                .owns(
+                    watch_namespace
+                        .get_api::<DeserializeGuard<listener::v1alpha1::Listener>>(&client),
+                    watcher::Config::default(),
+                )
+                .owns(
+                    watch_namespace.get_api::<DeserializeGuard<PodDisruptionBudget>>(&client),
+                    watcher::Config::default(),
+                )
+                .owns(
+                    watch_namespace.get_api::<DeserializeGuard<RoleBinding>>(&client),
+                    watcher::Config::default(),
+                )
+                .owns(
+                    watch_namespace.get_api::<DeserializeGuard<Service>>(&client),
+                    watcher::Config::default(),
+                )
+                .owns(
+                    watch_namespace.get_api::<DeserializeGuard<ServiceAccount>>(&client),
+                    watcher::Config::default(),
+                )
+                .owns(
+                    watch_namespace.get_api::<DeserializeGuard<StatefulSet>>(&client),
                     watcher::Config::default(),
                 )
                 .watches(

--- a/tests/templates/kuttl/cluster-operation/60-assert.yaml
+++ b/tests/templates/kuttl/cluster-operation/60-assert.yaml
@@ -1,0 +1,84 @@
+---
+# The recreated StatefulSet must bring the cluster back to ready, and the recreated
+# objects must carry an owner reference back to the SupersetCluster so that garbage
+# collection still works for them.
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: recreate-owned-resources
+timeout: 600
+commands:
+  - script: kubectl -n $NAMESPACE wait --for=condition=available supersetclusters.superset.stackable.tech/superset --timeout 601s
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: superset-node-default
+  ownerReferences:
+    - apiVersion: superset.stackable.tech/v1alpha1
+      controller: true
+      kind: SupersetCluster
+      name: superset
+status:
+  readyReplicas: 2
+  replicas: 2
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: superset-serviceaccount
+  ownerReferences:
+    - apiVersion: superset.stackable.tech/v1alpha1
+      controller: true
+      kind: SupersetCluster
+      name: superset
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: superset-rolebinding
+  ownerReferences:
+    - apiVersion: superset.stackable.tech/v1alpha1
+      controller: true
+      kind: SupersetCluster
+      name: superset
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: superset-node
+  ownerReferences:
+    - apiVersion: superset.stackable.tech/v1alpha1
+      controller: true
+      kind: SupersetCluster
+      name: superset
+---
+apiVersion: listeners.stackable.tech/v1alpha1
+kind: Listener
+metadata:
+  name: superset-node
+  ownerReferences:
+    - apiVersion: superset.stackable.tech/v1alpha1
+      controller: true
+      kind: SupersetCluster
+      name: superset
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: superset-node-default-headless
+  ownerReferences:
+    - apiVersion: superset.stackable.tech/v1alpha1
+      controller: true
+      kind: SupersetCluster
+      name: superset
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: superset-node-default-metrics
+  ownerReferences:
+    - apiVersion: superset.stackable.tech/v1alpha1
+      controller: true
+      kind: SupersetCluster
+      name: superset

--- a/tests/templates/kuttl/cluster-operation/60-delete-owned-resources.yaml
+++ b/tests/templates/kuttl/cluster-operation/60-delete-owned-resources.yaml
@@ -1,0 +1,65 @@
+---
+# Every resource the operator applies carries an ownerReference and a `.owns()` watch
+# (main.rs): deleting it must trigger a reconcile of the SupersetCluster that re-applies it,
+# proving the `.owns()` routing and the ClusterRole `watch` verbs end to end.
+# `.watches()` registrations can't be tested this way: the operator never recreates
+# what it didn't apply.
+#
+# Resources are discovered by label (ClusterResources::add enforces the labels on
+# everything the operator applies), so new resources and kinds are covered
+# automatically. Labels over-match on derived objects, so each match must also carry
+# a controller ownerReference pointing at the SupersetCluster; kinds that can never pass
+# that gate are excluded up front. Recreation is proven by UID change, and a floor
+# guard catches a selector that silently matches nothing.
+#
+# Secrets are excluded: the auto-generated SECRET_KEY Secret is a generate-once value
+# that is deliberately not `.owns()`-registered, so deleting it would not trigger a
+# recreation.
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: delete-owned-resources
+timeout: 300
+commands:
+  - script: |
+      set -eu
+
+      delete_and_await_recreation() {
+        resource=$1
+        old_uid=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.uid}')
+        kubectl delete -n "$NAMESPACE" "$resource" --wait=false
+        # Recreation is a single reconcile away, so this normally succeeds on the
+        # first iteration; 30s is a generous upper bound well below the step timeout.
+        for _ in $(seq 1 30); do
+          new_uid=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
+          if [ -n "$new_uid" ] && [ "$new_uid" != "$old_uid" ]; then
+            return 0
+          fi
+          sleep 1
+        done
+        echo "$resource was not recreated (old uid: $old_uid, current: '${new_uid:-}')" >&2
+        return 1
+      }
+
+      selector="app.kubernetes.io/instance=superset,app.kubernetes.io/managed-by=superset.stackable.tech_supersetcluster"
+      excluded="^(pods|persistentvolumeclaims|endpoints|events|secrets)$|^endpointslices\.|^controllerrevisions\.|^events\."
+
+      deleted=0
+      for kind in $(kubectl api-resources --verbs=list --namespaced -o name | grep -Ev "$excluded" | sort); do
+        for resource in $(kubectl get -n "$NAMESPACE" "$kind" -l "$selector" -o name 2>/dev/null); do
+          owner=$(kubectl get -n "$NAMESPACE" "$resource" -o jsonpath='{.metadata.ownerReferences[?(@.controller==true)].kind}/{.metadata.ownerReferences[?(@.controller==true)].name}' 2>/dev/null || true)
+          if [ "$owner" != "SupersetCluster/superset" ]; then
+            echo "skipping $resource: controller owner is '${owner:-none}', not the SupersetCluster"
+            continue
+          fi
+          delete_and_await_recreation "$resource"
+          deleted=$((deleted + 1))
+        done
+      done
+
+      # Guard against the sweep silently matching nothing (wrong selector, renamed
+      # labels): the fixture is known to produce well over this many owned resources.
+      if [ "$deleted" -lt 6 ]; then
+        echo "only $deleted labelled resources were swept - the label selector is broken" >&2
+        exit 1
+      fi


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/878

```
--- PASS: kuttl (650.34s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/cluster-operation_superset-latest-6.1.0_openshift-false (650.33s)
PASS
```


This PR ensures that the operator now watches all resources that it creates and early-exits the reconcile action when the cluster is marked for deletion. This is tested at unit-test level, as well as by adding a step to one of the kuttl tests to delete all relevant objects and assert that they are re-created.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [x] Release note snippet added in parent issue

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
