### PR TITLE
fix: make container name accessor infallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   Since `volumeClaimTemplates` cannot be updated in place, StatefulSets created by older
   operator versions cannot be updated after the upgrade: delete the `node` StatefulSet(s)
   so that the operator immediately recreates them with the new labels ([#779]).
-- Make operations infallible where dependent on static inputs ([#785]).
+- Make operations infallible where dependent on static inputs ([#785], [#788]).
 
 ### Removed
 
@@ -49,6 +49,7 @@
 [#779]: https://github.com/stackabletech/superset-operator/pull/779
 [#781]: https://github.com/stackabletech/superset-operator/pull/781
 [#785]: https://github.com/stackabletech/superset-operator/pull/785
+[#788]: https://github.com/stackabletech/superset-operator/pull/788
 
 ## [26.7.0] - 2026-07-21
 

--- a/rust/operator-binary/src/controller/build/resource/mod.rs
+++ b/rust/operator-binary/src/controller/build/resource/mod.rs
@@ -80,6 +80,8 @@ const STACKABLE_CERTS_DIR: &str = "/stackable/certs/";
 /// Path of the statsd-exporter binary launched by the `metrics` sidecar.
 const STATSD_EXPORTER_BINARY: &str = "/stackable/statsd_exporter";
 
+// The metrics container has no logging configuration, so it is not a `Container` variant and
+// carries its name directly.
 constant!(METRICS_CONTAINER_NAME: ContainerName = "metrics");
 
 // Name of the listener volume. It is a PVC, so the same name is used as the volume/mount name and
@@ -255,7 +257,7 @@ pub(crate) fn build_superset_container_builder(
     rolegroup_config: &SupersetRoleGroupConfig,
     role_specific_env_vars: EnvVarSet,
 ) -> ContainerBuilder {
-    let mut superset_cb = new_container_builder(&Container::Superset.to_container_name());
+    let mut superset_cb = new_container_builder(Container::Superset.name());
 
     superset_cb
         .image_from_product_image(&validated.image)
@@ -315,7 +317,7 @@ pub(crate) fn build_vector_container(
         .as_ref()
         .map(|vector_log_config| {
             vector_container(
-                &Container::Vector.to_container_name(),
+                Container::Vector.name(),
                 &validated.image,
                 vector_log_config,
                 &validated.role_group_resource_names(superset_role, role_group_name),

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -460,11 +460,18 @@ impl From<&SupersetRole> for RoleName {
     }
 }
 
+// Typed container names. They must match the strum `Display` (kebab-case) of the
+// `v1alpha1::Container` variants, which is pinned by a unit test.
+constant!(SUPERSET_CONTAINER_NAME: ContainerName = "superset");
+constant!(VECTOR_CONTAINER_NAME: ContainerName = "vector");
+
 impl v1alpha1::Container {
-    /// The type-safe container name for this variant (matching its kebab-case serialization).
-    pub fn to_container_name(&self) -> ContainerName {
-        ContainerName::from_str(&self.to_string())
-            .expect("a Container variant name is a valid container name")
+    /// The typed container name of this variant.
+    pub fn name(&self) -> &'static ContainerName {
+        match self {
+            v1alpha1::Container::Superset => &SUPERSET_CONTAINER_NAME,
+            v1alpha1::Container::Vector => &VECTOR_CONTAINER_NAME,
+        }
     }
 }
 
@@ -635,8 +642,17 @@ mod tests {
     use super::{
         BEAT_ROLE_NAME, ClusterName, DEFAULT_LISTENER_CLASS, INTERNAL_SECRET_SECRET_KEY,
         MAPBOX_API_KEY_ENV, MAPBOX_API_KEY_SECRET_KEY, NODE_ROLE_NAME, SECRET_KEY_ENV,
-        SupersetRole, WORKER_ROLE_NAME, v1alpha1,
+        SUPERSET_CONTAINER_NAME, SupersetRole, VECTOR_CONTAINER_NAME, WORKER_ROLE_NAME, v1alpha1,
     };
+
+    /// The typed container names returned by `name` must agree with the strum `Display` of
+    /// `v1alpha1::Container`, which the logging configuration still uses as the per-container key.
+    #[test]
+    fn container_names_match_display() {
+        for container in v1alpha1::Container::iter() {
+            assert_eq!(container.name().to_string(), container.to_string());
+        }
+    }
 
     #[test]
     fn test_constants() {
@@ -645,6 +661,8 @@ mod tests {
         let _ = *NODE_ROLE_NAME;
         let _ = *WORKER_ROLE_NAME;
         let _ = *BEAT_ROLE_NAME;
+        let _ = *SUPERSET_CONTAINER_NAME;
+        let _ = *VECTOR_CONTAINER_NAME;
         let _ = *SECRET_KEY_ENV;
         let _ = *INTERNAL_SECRET_SECRET_KEY;
         let _ = *MAPBOX_API_KEY_ENV;


### PR DESCRIPTION
<!--
This file is automatically generated from the templates in stackabletech/operator-templating
DO NOT MANUALLY EDIT THIS FILE
-->

## Description

Part of https://github.com/stackabletech/issues/issues/883

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
